### PR TITLE
core1.0: add <scoped-name> grammar element etc.

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -407,6 +407,10 @@ Each pair of messages is to be considered individually.
 --> "have" is invalid; "have" argument "qux1.0" does not correspond to any "want" argument
 ```
 
+The server is under no obligation of agreeing to any module or capability.
+Clients should be prepared to gracefully handle unavailable modules or capabilities.
+If the client finds that the server has not agreed to a module or capability that the client needs, it must exit.
+
 ## 5. Message types for `vt6/core1`
 
 ### 5.1. The `core1.sub` message

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -133,7 +133,8 @@ strict-bareword = ( letter / "_" ) *( letter / "-" / "_" )
 
 module-name    = strict-bareword version-number ; major version number only
 
-message-type   = "want" / "have" / ( module-name "." strict-bareword )
+scoped-name    = module-name "." strict-bareword
+message-type   = "want" / "have" / scoped-name
 
 message        = "(" *space message-type *space *( ( s-expression / atom ) *space ) ")"
 ```
@@ -209,14 +210,17 @@ If, while parsing a message stream, a message in the stream exceeds the recipien
 
 ## 3. Modules
 
-The VT6 protocol specification is divided into **modules**, each of which has a **name**.
+The VT6 protocol specification is divided into **modules**, each of which MUST have a **name** which is accepted by `<module-name>` (see section 2.2).
 For example, this document specifies the `core1` module.
 
 Each module contains the message types, properties and capabilities defined in its specification (see below).
-For each message type, property and capability defined in a module's specification, the part of its name before the dot MUST be equivalent to the module name.
+Each message type MUST have a **name** which is accepted by `<message-type>` (see section 2.2).
+Each property or capability MUST have a **name** which is accepted by `<scoped-name>` (see section 2.2).
+
+For each message type, property and capability (except for the `want` and `have` message types defined in section 4), the part of its name before the dot MUST be equivalent to the name of the module whose specification defines it.
 For example, a module with a name of `example2` may define a message type named `example2.foo` and a property named `example2.bar`, but not a message type named `example1.foo` or a property named `sample2.bar`.
 
-Each **message type** is defined by its name (see section 2.2) and a set of criteria describing when a message whose first element is the message type's name is to be considered valid by the recipient.
+Each **message type** is defined by its name and a set of criteria describing when a message whose first element is the message type's name is to be considered valid by the recipient.
 These criteria include at least:
 
 - the directionality (whether the message may be sent from a client to a server, or vice-versa, or both),
@@ -230,7 +234,7 @@ Each concrete value of a property is represented as either an `<atom>` or an `<s
 The value of a property may influence how the server reacts to a message from the client.
 It may also influence how the client reacts to a message from the server if (and only if) the client has subscribed to this property (see section 5.1).
 
-Each property is defined by its name (see section 2.2) and at least the following criteria:
+Each property is defined by its name and at least the following criteria:
 
 - the set of values that the property can have,
 - the capabilities that the server must agree to before the client may subscribe to this property (see section 4),
@@ -239,8 +243,6 @@ Each property is defined by its name (see section 2.2) and at least the followin
 
 A **capability** is an aspect of the module specification that may not be supported by every server.
 The server therefore has to agree to a capability (see section 4) before client and server can use the message types, properties or other behaviors restricted to this capability, even if the usage of the module which contains them has already been agreed to by the server.
-
-Each capability is defined by its name (see section 2.2) and by the message types, properties or other behaviors restricted to this capability.
 
 For each object (message type, property or capability) in a module, that module SHALL NOT contain a different object of the same name.
 


### PR DESCRIPTION
This clarifies that `want` and `have` are not valid names for properties and capabilities. (Closes #2.)

Also, describe client behavior if server does not agree to requested modules/capabilities.