### PR TITLE
core1.0: initial spec for the core1.{sub,pub,set} messages

### DIFF
--- a/notes/stefans-notes.md
+++ b/notes/stefans-notes.md
@@ -1,5 +1,14 @@
 # Stefan's notes
 
+## Open points
+
+* `core` module
+  * Are the definitions in `core1.0` compatible with the notion of proxying that is going to be introduced in a subsequent module (maybe `mux1`)?
+  * We should consider allowing numbers everywhere in barewords. Quotes around number literals are cumbersome.
+  * Properties right now are scoped to the module level. What about properties of objects? For instance, in the UI library, clients may define an arbitrary number of panels, which each have width/height.
+* job control module
+  * Need to devise a method to establish a notion of pipe topology on the server, e.g. for the "file type hint" message that enables syntax highlighting, where the last file type hint in a pipe wins.
+
 ## Learning resources
 
 * [The TTY demystified](http://www.linusakesson.net/programming/tty/)

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -417,15 +417,124 @@ If the client finds that the server has not agreed to a module or capability tha
 
 ### 5.1. The `core1.sub` message
 
-TODO
+- Directionality: client to server
+- Required capabilities: none
+- Number of arguments: one or more
+
+A client can send a `core1.sub` message to establish a **subscription** to a nonzero number of properties.
+The arguments of the `core1.sub` message are the names of the properties which the client wishes to subscribe to.
+
+*Rationale:* It is intentional that subscribing to a property is the only way for a client to retrieve a property's value.
+This design nudges implementors towards handling server-initiated changes to properties properly.
+Clients which only want to get the value of a property once are free to ignore any subsequent `core1.pub` messages.
+
+A `core1.sub` message is invalid (within the meaning of section 2.4) if any of its arguments is:
+
+- not the name of a property,
+- the name of a property in a module to whose usage the server has not agreed, or
+- the name of a property which is restricted to a capability to which the server has not agreed.
+
+When a server receives a valid `core1.sub` message, it MUST subscribe the sending client to all properties in the message's argument list, and immediately notify the client with a corresponding `core1.pub` message (see below).
 
 ### 5.2. The `core1.pub` message
 
-TODO
+- Directionality: server to client
+- Required capabilities: none
+- Number of arguments: two or more (must be even)
+
+A server can send a `core1.pub` message to inform a client of the values of certain properties.
+It MUST have an even number of arguments.
+The argument list consists of pairs of property names and property values.
+That is, the second argument is the value of the property whose name is the first argument; the fourth argument (if present) is the value of the property whose name is the third argument; and so on.
+
+A `core1.pub` message is invalid (within the meaning of section 2.4) if any of its odd-numbered arguments is:
+
+- not the name of a property,
+- the name of a property in a module to whose usage the server has not agreed,
+- the name of a property which is restricted to a capability to which the server has not agreed, or
+- the name of a property to which the recipient of the `core1.pub` message has not subscribed.
+
+Moreover, a `core1.pub` message is invalid if any of its even-numbered arguments is a property value which is not valid for the property in question according to the specification defining the property.
+
+A `core1.pub` message can be sent by the server at any time to notify the client of changes to the values of properties that the client has subscribed to.
+Moreover, a `core1.pub` message MUST be sent by the server immediately upon receiving a valid `core1.sub` or `core1.set` message.
+This message MUST contain the values of all properties named in the `core1.pub` or `core1.set` message, in the same order.
+For `core1.pub` messages, this applies regardless of whether the client sending the message subscribes to properties for the first time, or whether subscriptions to these properties already existed for this client.
+
+The following snippet shows examples of valid and invalid pairs of `core1.sub` messages and `core1.pub` replies.
+The snippet is not a single message stream.
+Each pair of messages is to be considered individually.
+The snippet assumes that `foo1.bar` and `foo1.baz` are properties which are defined by the module `foo1` and which can assume arbitrary values, and that the server has agreed to using `foo1` and to all capabilities required by these properties.
+
+```vt6
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar hello-world foo1.baz "20")
+--> valid; property "foo1.bar" has the value "hello-world" and "foo1.baz" has the value "20"
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar "hello-world" foo1.baz "20")
+--> valid, and semantically identical to the previous example since the bareword hello-world represents the same string as the quoted string "hello-world"
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar (hello (world)) foo1.baz "20")
+--> valid; property values may be arbitrarily complex s-expressions if the spec defining the property allows it
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar hello-world foo1.baz)
+--> invalid; odd number of arguments
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar hello-world)
+--> invalid; missing a property mentioned in the `core1.sub` message
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.bar hello-world foo1.baz "20" foo1.extra "10")
+--> invalid; references a property not mentioned in the `core1.sub` message
+
+(core1.sub foo1.bar foo1.baz)
+(core1.pub foo1.baz "20" foo1.bar hello-world)
+--> invalid; properties not listed in correct order
+```
 
 ### 5.3. The `core1.set` message
 
-TODO
+- Directionality: client to server
+- Required capabilities: none
+- Number of arguments: two or more (must be even)
+
+A client can send a `core1.set` message to change the value of one or more properties.
+The argument list of a `core1.set` message has the same form as that of a `core1.pub` message (pairs of property names and values).
+
+A `core1.set` message is invalid (within the meaning of section 2.4) if any of its odd-numbered arguments is:
+
+- not the name of a property,
+- the name of a property in a module to whose usage the server has not agreed, or
+- the name of a property which is restricted to a capability to which the server has not agreed.
+
+Notably, the message is not invalid if any of its even-numbered arguments is a value that is not permissible for the property in question.
+
+*Rationale:* For non-trivial properties, the client might not have enough information to decide whether a given value is valid.
+
+Setting a property implies subscribing to the property.
+That is, a `core1.set` message sent from a client to a server implies a `core1.sub` message from the same client to the same server that mentions the same properties that are mentioned in the `core1.set` message.
+This does not mean, however, that a separate `core1.pub` message must be sent to answer the implied `core1.pub` message.
+For example,
+
+```vt6
+# this message...
+(core1.set foo1.bar value1 foo1.baz value2)
+# ...implies this message...
+(core1.sub foo1.bar foo1.baz)
+# ...and may result in a reply like this
+(core1.pub foo1.bar value1 foo1.baz value3)
+```
+
+*Rationale:* For properties that only need to be set once, this reduces the number of messages required from four (sub-pub-set-pub) to two (set-pub).
+
+A client's request to change the value of a property does not imply any obligation of the server to comply with this request.
+The server may refuse to change the property's value at all (especially if the property is read-only), it may comply with the request, or set the property to an entirely different value, as long as the value is valid according to the property's specification.
+This is why a `core1.pub` message is sent as a reply for a `core1.set` message.
+The client SHOULD observe the `core1.pub` reply to learn whether the requested changes were accepted.
 
 ## 6. Properties for `vt6/core1`
 
@@ -442,20 +551,3 @@ TODO only if large-messages capability
 ### 7.1. The `core1.large-messages` capability
 
 TODO this is a separate capability because simple implementations might want to hardcode their buffer size
-
-<!--
-
-TODO: define message format based on s-expressions; example message exchange ("->" is client-to-server, "<-" vice versa):
-
-   ->    (want core1 ui2 cli1)
-   <-    (have core1.3 ui2.5)
-   ->    (core1.sub ui2.width ui2.height)
-   <-    (core1.pub ui2.width 80 ui2.height 25)
-
-NOTE: no need for multiplexing of messages onto standard in/out, or text onto message in/out, unless in multiplexed mode
-
-NOTE: Not for this module, but: Syntax highlighting to be achieved by sending a "file type hint" message on message out.
-When multiple programs form a pipe, the latest file type hint (in pipe chronology) wins.
-NOTE: This requires the job control plugin to have a method of establishing a notion of pipe topology on the server.
-
--->

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -458,8 +458,8 @@ Moreover, a `core1.pub` message is invalid if any of its even-numbered arguments
 
 A `core1.pub` message can be sent by the server at any time to notify the client of changes to the values of properties that the client has subscribed to.
 Moreover, a `core1.pub` message MUST be sent by the server immediately upon receiving a valid `core1.sub` or `core1.set` message.
-This message MUST contain the values of all properties named in the `core1.pub` or `core1.set` message, in the same order.
-For `core1.pub` messages, this applies regardless of whether the client sending the message subscribes to properties for the first time, or whether subscriptions to these properties already existed for this client.
+This message MUST contain the values of all properties named in the `core1.sub` or `core1.set` message, in the same order.
+For `core1.sub` messages, this applies regardless of whether the client sending the message subscribes to properties for the first time, or whether subscriptions to these properties already existed for this client.
 
 The following snippet shows examples of valid and invalid pairs of `core1.sub` messages and `core1.pub` replies.
 The snippet is not a single message stream.
@@ -517,7 +517,7 @@ Notably, the message is not invalid if any of its even-numbered arguments is a v
 
 Setting a property implies subscribing to the property.
 That is, a `core1.set` message sent from a client to a server implies a `core1.sub` message from the same client to the same server that mentions the same properties that are mentioned in the `core1.set` message.
-This does not mean, however, that a separate `core1.pub` message must be sent to answer the implied `core1.pub` message.
+This does not mean, however, that a separate `core1.pub` message must be sent to answer the implied `core1.sub` message.
 For example,
 
 ```vt6


### PR DESCRIPTION
This is... completely HUGE... and kind of immortal. I definitely need to reread this tomorrow or so when my mind has recovered from this writing session.

@hkgit03 Feel free to take a look. However, this is so big that we'd probably be better served by reviewing this in person. After writing this down, I have some reservations regarding all the complexity that we're introducing here.

In related news, I've moved the todolist-in-a-comment from the bottom of `core1.0` into my notes file. I also added some notes that we should also go through in our next design session.