### PR TITLE
core1.0: define the large-messages capability and associated properties

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -156,7 +156,7 @@ A **VT6 message stream** (or just **message stream**, if the term is not ambiguo
 As with s-expressions above, a message stream is also a valid UTF-8-encoded string, so implementations can reuse existing Unicode support libraries.
 
 ```abnf
-fenced-message-stream = escape-char message-stream escape-char
+fenced-msg-stream = escape-char message-stream escape-char
 
 escape-char = %x1B
 ```
@@ -536,12 +536,12 @@ The server may refuse to change the property's value at all (especially if the p
 This is why a `core1.pub` message is sent as a reply for a `core1.set` message.
 The client SHOULD observe the `core1.pub` reply to learn whether the requested changes were accepted.
 
-*Rationale:* For example, consider the case of the client trying to set `core1.client-max-message-bytes` to `32768`.
+*Rationale:* For example, consider the case of the client trying to set `core1.client-msg-bytes-max` to `32768`.
 The server might reject this, and report the previous value in the `core1.pub` response; or it might choose a value inbetween the previous and the requested value because it absolutely cannot process messages larger than that.
 
 ## 6. Properties for `vt6/core1`
 
-### 6.1. The `core1.server-max-message-bytes` property
+### 6.1. The `core1.server-msg-bytes-max` property
 
 - Acceptable values: unsigned integer literals
 - Required capabilities: none
@@ -558,7 +558,7 @@ The property is read-only unless the server agrees to the `core1.large-messages`
 
 TODO define a library of standard data types in the grammar section, that can be reused in property definitions like this one
 
-### 6.2. The `core1.client-max-message-bytes` property
+### 6.2. The `core1.client-msg-bytes-max` property
 
 - Acceptable values: unsigned integer literals
 - Required capabilities: none
@@ -577,4 +577,4 @@ The property is read-only unless the server agrees to the `core1.large-messages`
 
 ### 7.1. The `core1.large-messages` capability
 
-This capability enables the client to negotiate different (usually larger) message sizes with the server, by changing the values of the `core1.server-max-message-bytes` and `core1.client-max-message-bytes` properties.
+This capability enables the client to negotiate different (usually larger) message sizes with the server, by changing the values of the `core1.server-msg-bytes-max` and `core1.client-msg-bytes-max` properties.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -191,7 +191,7 @@ A message is **invalid** if...
 
 - the message's arguments do not conform to the requirements for the message's type, as stated in the specification defining the message type in question,
 
-- the size of the bytestring encoding the message exceeds the recipient's maximum message size (see sections 6.1 and 6.2), usually 4096 bytes, or
+- the size of the bytestring encoding the message exceeds the recipient's maximum message size (see sections 6.1 and 6.2), usually 1024 bytes, or
 
 - the message type is unknown or its use has not been agreed to by the server (see section 4).
 
@@ -518,7 +518,7 @@ Notably, the message is not invalid if any of its even-numbered arguments is a v
 Setting a property implies subscribing to the property.
 That is, a `core1.set` message sent from a client to a server implies a `core1.sub` message from the same client to the same server that mentions the same properties that are mentioned in the `core1.set` message.
 This does not mean, however, that a separate `core1.pub` message must be sent to answer the implied `core1.sub` message.
-For example,
+For example:
 
 ```vt6
 # this message...
@@ -536,18 +536,45 @@ The server may refuse to change the property's value at all (especially if the p
 This is why a `core1.pub` message is sent as a reply for a `core1.set` message.
 The client SHOULD observe the `core1.pub` reply to learn whether the requested changes were accepted.
 
+*Rationale:* For example, consider the case of the client trying to set `core1.client-max-message-bytes` to `32768`.
+The server might reject this, and report the previous value in the `core1.pub` response; or it might choose a value inbetween the previous and the requested value because it absolutely cannot process messages larger than that.
+
 ## 6. Properties for `vt6/core1`
 
 ### 6.1. The `core1.server-max-message-bytes` property
 
-TODO only if large-messages capability
+- Acceptable values: unsigned integer literals
+- Required capabilities: none
+- Influencing capabilities: `core1.large-messages`
+- Can be set by client: only with `core1.large-messages`
+
+The value of this property is the maximum length of a message sent from the server to the client in bytes.
+The initial value MUST NOT be larger than 1024.
+
+*Rationale:* The upper limit is important because clients are therefore assured that a 1 KiB buffer can hold any single message sent by the server, unless a different limit is negotiated.
+We choose this standard buffer size of 1 KiB such that most, if not all, messages that ever need to be sent fit into this buffer, without wasting too much memory on buffers.
+
+The property is read-only unless the server agrees to the `core1.large-messages` capability.
+
+TODO define a library of standard data types in the grammar section, that can be reused in property definitions like this one
 
 ### 6.2. The `core1.client-max-message-bytes` property
 
-TODO only if large-messages capability
+- Acceptable values: unsigned integer literals
+- Required capabilities: none
+- Influencing capabilities: `core1.large-messages`
+- Can be set by client: only with `core1.large-messages`
+
+The value of this property is the maximum length of a message sent from the client to the server in bytes.
+The initial value MUST NOT be smaller than 1024.
+
+*Rationale:* The lower limit is important because clients are therefore assured that any messages smaller than 1 KiB will be accepted by any server, unless a different limit is negotiated.
+The rationale from section 6.1 applies respectively.
+
+The property is read-only unless the server agrees to the `core1.large-messages` capability.
 
 ## 7. Capabilities for `vt6/core1`
 
 ### 7.1. The `core1.large-messages` capability
 
-TODO this is a separate capability because simple implementations might want to hardcode their buffer size
+This capability enables the client to negotiate different (usually larger) message sizes with the server, by changing the values of the `core1.server-max-message-bytes` and `core1.client-max-message-bytes` properties.


### PR DESCRIPTION
This also changes the default message buffer sizes to 1 KiB (down from 4 KiB). This is somewhat controversial, so I'll be putting this up for discussion.