### PR TITLE
core1: add section "Predefined property types"

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -310,8 +310,8 @@ The name of any private module SHOULD start with two leading underscores.
 ### 3.4. Predefined property types
 
 ```abnf
-integer          = "0" | ( 0*1sign nzdigit *digit )
-unsigned-integer = "0" | ( nzdigit *digit )
+integer          = "0" / ( [sign] nzdigit *digit )
+unsigned-integer = "0" / ( nzdigit *digit )
 
 sign = "+" / "-"
 ```
@@ -319,7 +319,7 @@ sign = "+" / "-"
 When a property is said to **accept integer values**, this means that the set of acceptable values for this property is the set of all atoms whose string value matches the `<integer>` grammar element defined above.
 Analogously, when a property is said to **accept unsigned integer values**, this means that the set of acceptable values for this property is the set of all atoms whose string value matches the `<unsigned-integer>` grammar element defined above.
 
-In both these cases, the numerical value of each such atom is that value which is returned when the `atoll()` function as defined in [the POSIX.1 specification](http://pubs.opengroup.org/onlinepubs/9699919799/) is applied to the string value of the atom.
+In both these cases, the numerical value of each such atom is that value which is returned when the `atoll()` function as defined in [the POSIX.1 specification](http://pubs.opengroup.org/onlinepubs/9699919799/functions/atoll.html) is applied to the string value of the atom.
 The module specification defining the property may impose additional restrictions on the numerical value of the property.
 
 Section 6 of this specification uses the property types defined in this section.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -307,6 +307,27 @@ The name of any private module SHOULD start with two leading underscores.
 
 *Rationale:* We strive to avoid name clashes between modules by different vendors, and reserve short module names for official modules to minimize message length for common messages.
 
+### 3.4. Predefined property types
+
+```abnf
+integer          = "0" | ( 0*1sign nzdigit *digit )
+unsigned-integer = "0" | ( nzdigit *digit )
+
+sign = "+" / "-"
+```
+
+When a property is said to **accept integer values**, this means that the set of acceptable values for this property is the set of all atoms whose string value matches the `<integer>` grammar element defined above.
+Analogously, when a property is said to **accept unsigned integer values**, this means that the set of acceptable values for this property is the set of all atoms whose string value matches the `<unsigned-integer>` grammar element defined above.
+
+In both these cases, the numerical value of each such atom is that value which is returned when the `atoll()` function as defined in [the POSIX.1 specification](http://pubs.opengroup.org/onlinepubs/9699919799/) is applied to the string value of the atom.
+The module specification defining the property may impose additional restrictions on the numerical value of the property.
+
+Section 6 of this specification uses the property types defined in this section.
+Other module specifications which use some or all of the property types defined in this section SHALL reference this section.
+The recommended way to do so is by including the following sentence near the start of the specification:
+
+> This document uses the predefined property types from section 3.4 of the `vt6/core1.0` specification.
+
 ## 4. Protocol negotiation
 
 Before a client can use the message types, properties and capabilities of a module, usage of the module must have been agreed to by the server.
@@ -543,7 +564,7 @@ The server might reject this, and report the previous value in the `core1.pub` r
 
 ### 6.1. The `core1.server-msg-bytes-max` property
 
-- Acceptable values: unsigned integer literals
+- Acceptable values: unsigned integers
 - Required capabilities: none
 - Influencing capabilities: `core1.large-messages`
 - Can be set by client: only with `core1.large-messages`
@@ -556,11 +577,9 @@ We choose this standard buffer size of 1 KiB such that most, if not all, message
 
 The property is read-only unless the server agrees to the `core1.large-messages` capability.
 
-TODO define a library of standard data types in the grammar section, that can be reused in property definitions like this one
-
 ### 6.2. The `core1.client-msg-bytes-max` property
 
-- Acceptable values: unsigned integer literals
+- Acceptable values: unsigned integers
 - Required capabilities: none
 - Influencing capabilities: `core1.large-messages`
 - Can be set by client: only with `core1.large-messages`


### PR DESCRIPTION
"Integer" and "unsigned integer" should be enough for now.

The value semantics definition references the `atoll()` function which returns `long long` integers, which covers 64-bit signed integers. If we ever need more than that, we can amend the spec to not rely on a reference to POSIX.1, but for now, I like how this saves me some typing and phrasing.