### PR TITLE
get rid of the core1.large-messages capability

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -566,34 +566,24 @@ The server might reject this, and report the previous value in the `core1.pub` r
 
 - Acceptable values: unsigned integers
 - Required capabilities: none
-- Influencing capabilities: `core1.large-messages`
-- Can be set by client: only with `core1.large-messages`
+- Can be set by client: yes
 
 The value of this property is the maximum length of a message sent from the server to the client in bytes.
-The initial value MUST NOT be larger than 1024.
+The value of this property MUST NOT be larger than 1024.
 
 *Rationale:* The upper limit is important because clients are therefore assured that a 1 KiB buffer can hold any single message sent by the server, unless a different limit is negotiated.
 We choose this standard buffer size of 1 KiB such that most, if not all, messages that ever need to be sent fit into this buffer, without wasting too much memory on buffers.
-
-The property is read-only unless the server agrees to the `core1.large-messages` capability.
 
 ### 6.2. The `core1.client-msg-bytes-max` property
 
 - Acceptable values: unsigned integers
 - Required capabilities: none
-- Influencing capabilities: `core1.large-messages`
-- Can be set by client: only with `core1.large-messages`
+- Can be set by client: yes
 
 The value of this property is the maximum length of a message sent from the client to the server in bytes.
-The initial value MUST NOT be smaller than 1024.
+The value of this property MUST NOT be smaller than 1024.
 
 *Rationale:* The lower limit is important because clients are therefore assured that any messages smaller than 1 KiB will be accepted by any server, unless a different limit is negotiated.
 The rationale from section 6.1 applies respectively.
 
-The property is read-only unless the server agrees to the `core1.large-messages` capability.
-
-## 7. Capabilities for `vt6/core1`
-
-### 7.1. The `core1.large-messages` capability
-
-This capability enables the client to negotiate different (usually larger) message sizes with the server, by changing the values of the `core1.server-msg-bytes-max` and `core1.client-msg-bytes-max` properties.
+The client MUST observe the server response when setting this property, because the server may reject the new property value or choose a compromise value.


### PR DESCRIPTION
Even if the server `(have core1.large-messages)`, that doesn't mean that the client can set the message sizes arbitrarily large, so the client must observe the `pub` response to its `set` message anyway. Therefore, the large-messages capability does not convey any tangible meaning.