### PR TITLE
core1.0: replace "message i/o" term by "server connection"

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -24,18 +24,19 @@ A **bidirectional text stream** is an object from which byte strings can be read
 A VT6 client SHALL have access to a bidirectional text stream, which is called this client's **standard input/output**.
 
 A VT6 client MAY have a method to gain access to further bidirectional text streams.
-Text streams obtained through this method shall be called **server connections**.
-When a client writes a byte string into a server connection, it SHALL be received by this client's server.
+Text streams obtained through this method are called **server connections**.
+When a client writes a byte string into a server connection, it MUST NOT be received by any process but this client's server.
 When a client reads a byte string from a server connection, it SHALL have been sent by this client's server.
-The server SHALL be able to distinguish between server connections opened by different clients, as well as server connections opened by the same client.
+The server SHALL be able to distinguish between server connections opened by different clients, as well as different server connections opened by the same client.
+This does not necessarily mean that the server can identify which server connection belongs to which client process.
 
-*Rationale:* The server connection is separate from the standard input and output for applications where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
+*Rationale:* The server connection is separate from the standard input and output for scenarios where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
 In POSIX, the message input and output replace the [special capabilities of terminal devices](https://linux.die.net/man/3/termios).
 
 If the platform allows VT6 client processes to be started while a VT6 server is not present, the client process MUST have a method to determine whether a VT6 server is present.
-If no VT6 server is present, the client process SHALL then not be considered a VT6 client for the purpose of this specification, and any other specifications that inherit the meaning of the term "VT6 client" from it.
+If no VT6 server is present, the client process SHALL not be considered a VT6 client for the purpose of this specification, and any other specifications that inherit the meaning of the term "VT6 client" from it.
 
-If a VT6 client has access to and is using at least one server connection, it is said to be operating in **normal mode**.
+If a VT6 client has a method to obtain server connections, it is said to be operating in **normal mode**.
 Otherwise, it is said to be operating in **multiplexed mode**.
 
 *Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional text stream to their server and have no way of establishing a separate bidirectional text stream to use as a server connection.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -15,24 +15,30 @@ A process which implements VT6 modules and exposes them to other processes is ca
 A process that consumes this functionality is called a **VT6 client**.
 A process that acts both as a VT6 client to at least one process and as a VT6 server to at least one process at the same time is called as **VT6 proxy**.
 
+*Rationale:* In the most common setup (programs being started by a shell inside a terminal emulator), the terminal emulator acts as the server.
+The shell and the programs started by it are the clients.
+
 A process that acts as a VT6 server SHALL be able to launch other processes which can then act as VT6 clients, or it alternatively SHALL be able to delegate this task to other processes.
 
-A VT6 client SHALL have access to two objects, or a method to gain access to two such objects, one from which byte strings can be read and one into which byte strings can be written.
-These objects shall be called this client's **standard input** and **standard output**, respectively.
+A **bidirectional text stream** is an object from which byte strings can be read and into which byte strings can be written.
+A VT6 client SHALL have access to a bidirectional text stream, which is called this client's **standard input/output**.
 
-A VT6 client MAY have access to two further objects, or a method to gain access to two such objects, one from which byte strings can be read and one into which byte strings can be written.
-These objects shall be called this client's **message input** and **message output**, respectively.
+A VT6 client MAY have a method to gain access to further bidirectional text streams.
+Text streams obtained through this method shall be called **server connections**.
+When a client writes a byte string into a server connection, it SHALL be received by this client's server.
+When a client reads a byte string from a server connection, it SHALL have been sent by this client's server.
+The server SHALL be able to distinguish between server connections opened by different clients, as well as server connections opened by the same client.
 
-*Rationale:* The message input and output are separate from the standard input and output for applications where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
+*Rationale:* The server connection is separate from the standard input and output for applications where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
 In POSIX, the message input and output replace the [special capabilities of terminal devices](https://linux.die.net/man/3/termios).
 
 If the platform allows VT6 client processes to be started while a VT6 server is not present, the client process MUST have a method to determine whether a VT6 server is present.
-It SHALL then not be considered a VT6 client for the purpose of this specification, and any other specifications that inherit the meaning of the term "VT6 client" from it.
+If no VT6 server is present, the client process SHALL then not be considered a VT6 client for the purpose of this specification, and any other specifications that inherit the meaning of the term "VT6 client" from it.
 
-If a VT6 client has access to and is using a message input and message output, it is said to be operating in **normal mode**.
+If a VT6 client has access to and is using at least one server connection, it is said to be operating in **normal mode**.
 Otherwise, it is said to be operating in **multiplexed mode**.
 
-*Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional connection to their server and have no way of establishing a separate bidirectional connection to use as message input/output.
+*Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional text stream to their server and have no way of establishing a separate bidirectional text stream to use as a server connection.
 The most prominent example of this is a client connected via a remote login protocol such as [SSH](https://tools.ietf.org/html/rfc4251).
 
 ### 1.1. POSIX platform
@@ -45,7 +51,7 @@ Therefore, VT6 clients MUST use the following method to determine whether a VT6 
 
 1. If the `VT6` environment variable is present, its content is the absolute path to a socket file.
    In this case, the VT6 client SHALL assume that a VT6 server is present, and operate in normal mode.
-   To obtain the message input and message output, the VT6 client SHALL connect to this socket file with socket type `SOCK_SEQPACKET`, and upon success, use the open socket as both message input and message output.
+   To obtain a server connection, the VT6 client SHALL connect to this socket file with socket type `SOCK_SEQPACKET`, and upon success, use the open socket as a server connection.
    When the connection to the socket fails, the VT6 client MAY either bail out, or continue to operate as if no VT6 server is present.
 
 2. If the `TERM` environment variable is present and contains the string `vt6`, the VT6 client SHALL assume that a VT6 server is present, and operate in multiplexed mode.
@@ -165,7 +171,7 @@ A message stream is **fenced** when it is preceded by one ESC character and succ
 
 ### 2.3. Server-client communication
 
-When a VT6 client is running in normal mode, it sends messages to its server by writing a message stream onto the message output, and receives messages from the server by reading a message stream from the message input.
+When a VT6 client is running in normal mode, it sends messages to its server by writing a message stream into a server connection, and receives messages from the server by reading a message stream from the same server connection.
 Furthermore, it can read input data from standard input and write output data to standard output.
 This specification does not restrict the form of these input and output data.
 
@@ -230,7 +236,7 @@ These criteria include at least:
 - the format and/or structure of said arguments,
 - the behavior that is expected of the recipient party upon having received the message.
 
-A **property** is a quantifiable aspect which describes the server or the connection between client and server.
+A **property** is a quantifiable aspect which describes the server or the server connection over which messages concerning this property are exchanged.
 Each concrete value of a property is represented as either an `<atom>` or an `<s-expression>`.
 The value of a property may influence how the server reacts to a message from the client.
 It may also influence how the client reacts to a message from the server if (and only if) the client has subscribed to this property (see section 5.1).


### PR DESCRIPTION
While writing the introduction for `sig1`, I noticed that the names "message input" and "message output" are problematic since a process can have multiple message IOs. I therefore used the word "server connection" instead, and then updated `core1` to:

1. use the term "server connection" instead of "message input/output" throughout the spec, and
2. require that the method to obtain a server connection can be used multiple times to obtain multiple server connections (which we will need for the frames module, where the shell opens additional server connections to convert into frame-restricted stdios).