### PR TITLE
promote the `nope` message into the eternal grammar

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -140,7 +140,7 @@ strict-bareword = ( letter / "_" ) *( letter / "-" / "_" )
 
 module-name  = strict-bareword
 scoped-name  = module-name "." strict-bareword
-message-type = "want" / "have" / scoped-name
+message-type = "want" / "have" / "nope" / scoped-name
 
 message        = "(" *space message-type *space *( ( s-expression / atom ) *space ) ")"
 ```
@@ -150,7 +150,7 @@ The first element of a message is therefore called the message's **type**.
 Any following elements of a message are called the message's **arguments**.
 A message may have arbitrarily many arguments, including zero arguments.
 As can be seen in the grammar definition above, a message type name consists of a module name (see section 3.1) and a strict bareword, separated by a dot (see section 3.3).
-As an exception, the message types "want" and "have" do not contain a module name (see section 4).
+As an exception, the message types "want", "have" and "nope" do not contain a module name (see sections 4 and 5).
 
 ```abnf
 message-stream = *( *space message ) *space
@@ -224,7 +224,7 @@ Each module contains the message types, properties and capabilities defined in i
 Each message type MUST have a **name** which is accepted by `<message-type>` (see section 2.2).
 Each property or capability MUST have a **name** which is accepted by `<scoped-name>` (see section 2.2).
 
-For each message type, property and capability (except for the `want` and `have` message types defined in section 4), the part of its name before the dot MUST be equivalent to the name of the module whose specification defines it.
+For each message type, property and capability (except for the `want`, `have` and `nope` message types defined in sections 4 and 5), the part of its name before the dot MUST be equivalent to the name of the module whose specification defines it.
 For example, a module with a name of `example2` may define a message type named `example.foo` and a property named `example.bar`, but not a message type named `sample.foo` or a property named `sample.bar`.
 
 Each **message type** is defined by its name and a set of criteria describing when a message whose first element is the message type's name is to be considered valid by the recipient.
@@ -239,13 +239,13 @@ These criteria include at least:
 A **property** is a quantifiable aspect which describes the server or the server connection over which messages concerning this property are exchanged.
 Each concrete value of a property is represented as either an `<atom>` or an `<s-expression>`.
 The value of a property may influence how the server reacts to a message from the client.
-It may also influence how the client reacts to a message from the server if (and only if) the client has subscribed to this property (see section 5.1).
+It may also influence how the client reacts to a message from the server if (and only if) the client has subscribed to this property (see section 6.1).
 
 Each property is defined by its name and at least the following criteria:
 
 - the set of values that the property can have,
 - the capabilities that the server must agree to before the client may subscribe to this property (see section 4),
-- whether, and under which circumstances, the client may set the property's value (see section 5.3),
+- whether, and under which circumstances, the client may set the property's value (see section 6.3),
 - how the behavior of client and server is influenced by the value of this property.
 
 A **capability** is an aspect of the module specification that may not be supported by every server.
@@ -306,7 +306,8 @@ As an additional rule, all versions of the `core` module MUST be backwards-compa
 This includes, specifically:
 
 - the parts of sections 1 and 2.3 that describe how client and server establish a connection to each other and use it to exchange messages, and
-- the syntax of `want` and `have` messages as described in sections 2.1 and 4.
+- the syntax of `want`, `have` and `nope` messages as described in sections 2.1 and 4.
+  Those message types are therefore called **eternal**.
 
 The backwards-compatibility requirement across major versions of `core` does not apply to those parts of the message syntax that can only be used after the initial `want` and `have` messages (namely, quoted strings and nested s-expressions).
 
@@ -335,7 +336,7 @@ Analogously, when a property is said to **accept unsigned integer values**, this
 In both these cases, the numerical value of each such atom is that value which is returned when the `atoll()` function as defined in [the POSIX.1 specification](http://pubs.opengroup.org/onlinepubs/9699919799/functions/atoll.html) is applied to the string value of the atom.
 The module specification defining the property may impose additional restrictions on the numerical value of the property.
 
-Section 6 of this specification uses the property types defined in this section.
+Section 7 of this specification uses the property types defined in this section.
 Other module specifications which use some or all of the property types defined in this section SHALL reference this section.
 The recommended way to do so is by including the following sentence near the start of the specification:
 
@@ -371,7 +372,7 @@ The first message that a client sends MUST be a `want` message, and the argument
 
 *Rationale:* All other modules depend on the definitions in `core`, so it must be negotiated first.
 
-A `want` message may contain multiple versions of the same module name.
+A `want` message may contain multiple major versions of the same module.
 For example, the following `want` message indicates that the client can use (at least) two different major versions of the `core` module, but only one major version of the `foo` module.
 
 ```vt6
@@ -390,11 +391,7 @@ Quoted strings are not allowed in this message.
 *Rationale:* Same as in section 4.1.
 
 Upon receiving a valid `want` message, the server MUST reply with a `have` message to indicate which modules and capabilities in that `have` message it agrees to.
-If it does not agree to any of the modules and capabilities requested, it MUST reply with a `have` message with zero arguments.
-If the `want` message is invalid, it MUST also reply with a `have` message with zero arguments, except if the server has already agreed to a version of `core`, in which case the error handling mechanisms defined by said version of `core` apply (regarding the version defined in this document, see section 5.4).
-
-*Rationale:* A client will typically wait for the `have` reply because the validity of subsequent messages depends on it.
-A missing `have` message might therefore stall the client forever.
+If the `want` message is valid, but the server does not agree to any of the modules and capabilities requested, it MUST reply with a `have` message with zero arguments.
 
 Each argument in the `have` message corresponds to an argument in the `want` message, except that modules and capabilities to which the server does not agree are omitted.
 This particularly means that the argument list of the `have` message MUST preserve the order of arguments in the `want` message.
@@ -455,9 +452,29 @@ The server is under no obligation of agreeing to any module or capability.
 Clients should be prepared to gracefully handle unavailable modules or capabilities.
 If the client finds that the server has not agreed to a module or capability that the client needs, it must exit.
 
-## 5. Message types for `vt6/core1.0`
+## 5. Other eternal message types
 
-### 5.1. The `core.sub` message
+### 5.1. The `nope` message
+
+- Directionality: any
+- Required capabilities: none
+- Number of arguments: none
+
+Upon receiving an invalid message, a server or client MAY reply by sending a `nope` message with no arguments.
+It MUST do so if:
+
+1. the recipient cannot determine the message type of the invalid message, or
+2. the recipient can determine, based on the message type of the invalid message, that the sender is waiting for a reply.
+
+As an exception, the recipient SHALL NOT send a `nope` message when a module or capability that the server has agreed to mandates a different behavior for the invalid message in question.
+
+*Rationale:* The purpose of the `nope` message is solely to unblock any processes which are waiting for a reply to their previous message.
+This module does not define any generic error reporting mechanisms beyond this message type.
+We consider it pointless to try to get any misbehaving process to start behaving correctly by pointing out their errors to them.
+
+## 6. Message types for `vt6/core1.0`
+
+### 6.1. The `core.sub` message
 
 - Directionality: client to server
 - Required capabilities: none
@@ -478,7 +495,7 @@ A `core.sub` message is invalid (within the meaning of section 2.4) if any of it
 
 When a server receives a valid `core.sub` message, it MUST subscribe the sending client to all properties in the message's argument list, and immediately notify the client with a corresponding `core.pub` message (see below).
 
-### 5.2. The `core.pub` message
+### 6.2. The `core.pub` message
 
 - Directionality: server to client
 - Required capabilities: none
@@ -581,25 +598,9 @@ The client SHOULD observe the `core.pub` reply to learn whether the requested ch
 *Rationale:* For example, consider the case of the client trying to set `core.client-msg-bytes-max` to `32768`.
 The server might reject this, and report the previous value in the `core.pub` response; or it might choose a value inbetween the previous and the requested value because it absolutely cannot process messages larger than that.
 
-### 5.4. The `core.nope` message
+## 7. Properties for `vt6/core1.0`
 
-- Directionality: any
-- Required capabilities: none
-- Number of arguments: none
-
-Upon receiving an invalid message, a server or client MAY reply by sending a `core.nope` message.
-It MUST do so if:
-
-1. the recipient cannot determine the message type of the invalid message, or
-2. the recipient can determine, based on the message type of the invalid message, that the sender is waiting for a reply.
-
-*Rationale:* The purpose of the `core.nope` message is solely to unblock any processes which are waiting for a reply to their previous message.
-This module does not define any generic error reporting mechanisms beyond this message type.
-We consider it pointless to try to get any misbehaving process to start behaving correctly by pointing out their errors to them.
-
-## 6. Properties for `vt6/core1.0`
-
-### 6.1. The `core.server-msg-bytes-max` property
+### 7.1. The `core.server-msg-bytes-max` property
 
 - Acceptable values: unsigned integers
 - Required capabilities: none
@@ -611,7 +612,7 @@ The default value of this property MUST NOT be larger than 1024.
 *Rationale:* The upper limit is important because clients are therefore assured that a 1 KiB buffer can hold any single message sent by the server, unless a different limit is negotiated.
 We choose this standard buffer size of 1 KiB such that most, if not all, messages that ever need to be sent fit into this buffer, without wasting too much memory on buffers.
 
-### 6.2. The `core.client-msg-bytes-max` property
+### 7.2. The `core.client-msg-bytes-max` property
 
 - Acceptable values: unsigned integers
 - Required capabilities: none
@@ -621,6 +622,6 @@ The value of this property is the maximum length of a message sent from the clie
 The default value of this property MUST NOT be smaller than 1024.
 
 *Rationale:* The lower limit is important because clients are therefore assured that any messages smaller than 1 KiB will be accepted by any server, unless a different limit is negotiated.
-The rationale from section 6.1 applies respectively.
+The rationale from section 7.1 applies respectively.
 
 The client MUST observe the server response when setting this property, because the server may reject the new property value or choose a compromise value.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -463,8 +463,8 @@ If the client finds that the server has not agreed to a module or capability tha
 Upon receiving an invalid message, a server or client MAY reply by sending a `nope` message with no arguments.
 It MUST do so if:
 
-1. the recipient cannot determine the message type of the invalid message, or
-2. the recipient can determine, based on the message type of the invalid message, that the sender is waiting for a reply.
+1. it cannot determine the message type of the invalid message, or
+2. it can determine, based on the message type of the invalid message, that the sender is waiting for a reply.
 
 As an exception, the recipient SHALL NOT send a `nope` message when a module or capability that the server has agreed to mandates a different behavior for the invalid message in question.
 


### PR DESCRIPTION
We previously had a special case that requires the server to answer an invalid `want` message with an empty `have` if no `core` has been negotiated yet, but it was not defined what the server should do
when the client sends an invalid message that is *not* a `want` message *before* having negotiated a version of `core`.

Promoting `nope` into the eternal grammar gives the server a consistent method of replying to any invalid messages regardless of the negotiation state.

To allow for future extension, add language to the specification of `nope` that allows any module to override it with a more specific error reporting mechanism if server and client agree to that module.