### PR TITLE
change want/have to only negotiate one module/capability at once

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -352,100 +352,111 @@ A server **agrees to** using a module or capability by answering a `want` messag
 
 - Directionality: client to server
 - Required capabilities: none
-- Number of arguments: one or more
+- Number of arguments: two or more for module request, exactly one for capability request
 
 Each argument MUST be a bareword.
 Quoted strings are not allowed in this message.
 
 *Rationale:* The syntax of the `want` message is deliberately minimized because of the compatibility requirements in section 3.2.
 
-```abnf
-module-name-with-major-version = module-name major-version
-```
+A client can send a `want` message to request usage of a module or capability to the server.
 
-The `want` message informs the server of modules and capabilities that the client wants to use.
-Each argument is a pair of module name and major version number as accepted by `<module-name-with-major-version>`, or a capability name as accepted by `<scoped-name>`.
-For each argument that is a capability name, the server MUST already have agreed to using a module that defines this capability.
-Alternatively, one of the arguments that comes before this argument MUST be a pair of that module's name and some major version, as accepted by `<module-name-with-major-version>`, such that there exists a specification for that module and major version defining this capability.
-
-The first message that a client sends MUST be a `want` message, and the argument list MUST start with at least one version of `core` (i.e., any of `core1`, `core2`, `core3`, and so on).
-
-*Rationale:* All other modules depend on the definitions in `core`, so it must be negotiated first.
-
-A `want` message may contain multiple major versions of the same module.
-For example, the following `want` message indicates that the client can use (at least) two different major versions of the `core` module, but only one major version of the `foo` module.
+When requesting a module, the first argument MUST be the module name, and the remaining arguments SHALL be the major versions of that module that the client supports.
+For example, the following `want` message indicates that the client wants to use either major version 1 or major version 2 of the `example` module.
 
 ```vt6
-(want core1 core2 foo1)
+(want example 1 2)
 ```
+
+When requesting a capability, the sole argument MUST be the capability name as accepted by `<scoped-name>`.
+For example, the following `want` message indicates that the client wants to use the `example.foo` capability.
+
+```vt6
+(want example.foo)
+```
+
+The first message that a client sends on each server connection MUST be a `want` message requesting the `core` module.
+
+*Rationale:* All other modules depend on the definitions in `core`, so it must be negotiated first.
 
 ### 4.2. The `have` message
 
 - Directionality: server to client
 - Required capabilities: none
-- Number of arguments: zero or more
+- Number of arguments: zero, one or three
 
 Each argument MUST be a bareword.
 Quoted strings are not allowed in this message.
 
 *Rationale:* Same as in section 4.1.
 
-Upon receiving a valid `want` message, the server MUST reply with a `have` message to indicate which modules and capabilities in that `have` message it agrees to.
-If the `want` message is valid, but the server does not agree to any of the modules and capabilities requested, it MUST reply with a `have` message with zero arguments.
+Upon receiving a valid `want` message, the server MUST reply with a `have` message to indicate if it agrees to using the requested module or capability.
+If the `want` message is valid, but the server does not agree to the requested module and capability, it MUST reply with a `have` message with zero arguments.
 
-Each argument in the `have` message corresponds to an argument in the `want` message, except that modules and capabilities to which the server does not agree are omitted.
-This particularly means that the argument list of the `have` message MUST preserve the order of arguments in the `want` message.
-From this and the definition of the `want` message also follows that the use of a module must be agreed to before any of its capabilities can be agreed to.
+If the `want` message requests usage of a module and the server agrees to using that module, it MUST reply with a `have` message with three arguments: the module name, the major and minor version of the specification supported by the server.
+Receipt of this `have` message entitles the client to use all message types, properties and behavior defined in a specification of that module with the same major version number and the same, or a smaller, minor version number, except for functionality dependent on capabilities.
+The major and minor version MUST be formatted according to the `<major-version>` and `<minor-version>` grammar elements defined above.
+The major version in the `have` message MUST be one of the major versions that appeared in the original `want` message.
 
-For `want` arguments that are capability names, the corresponding `have` argument is the same string, the capability name.
-A server SHALL NOT agree to using a capability if it has not previously agreed to using the module defining said capability, unless it agrees to using the module in the same `have` message.
-
-For `want` arguments that are pairs of module names and major version, the corresponding `have` argument is the original `want` argument, with a dot and a positive integer appended to it.
-The positive integer indicates the maximal minor version of this module that is understood by the server.
-Receipt of the `have` message containing this argument entitles the client to use all message types, properties and capabilities defined in a specification of that module with the same major version number and the same, or a smaller, minor version number.
-
+The server MUST NOT agree to using a module if it does not support any of the major versions of that module which were offered in the `want` message.
 The server MUST NOT agree to using multiple major versions of the same module, neither in a single `have` message or across multiple `have` messages on the same server connection.
 The server MAY agree to using different major versions of the same module on different server connections.
 
-When an argument in a `want` message is identical to an earlier argument in the same `want` message, or to an argument in an earlier `want` message, the server MUST reply consistently.
-If it did not agree to the earlier argument, it MUST NOT agree to this argument, and vice versa.
+When a `want` message concerns the same module as an earlier `want` message, the server MUST reply consistently.
+If it agreed to using a particular major version of a module in an earlier `have` message, and that major version is offered again in the current `have` message, it MUST agree to this major version and offer the same minor version as in the earlier `have` message.
+If it did not agree to using a particular major version of a module in an earlier `have` message, and that major version is offered again in the current `have` message, it MUST NOT agree to this major version.
 
-The following snippet shows examples of valid and invalid pairs of `want` messages and `have` replies.
-The snippet is not a single message stream.
-Each pair of messages is to be considered individually.
+If the `want` message requests usage of a capability and the server agrees to using that module, it MUST reply with a `have` message with a single argument: the capability name as accepted by `<scoped-name>`.
+Receipt of this `have` message entitles the client to use all message types, properties and behavior defined in a specification of that module with the same major version number and the same, or a smaller, minor version number, where such functionality depends on the negotiated capability.
+
+A server SHALL NOT agree to using a capability if it did not agree to using a module that defines this capability in any prior `have` message on the same server connection.
+
+When a `want` message concerns the same capability as an earlier `want` message, the server MUST reply consistently.
+If it agreed to using the capability in an earlier `have` message, it MUST agree to it again, and vice versa.
+
+The following snippet shows examples of valid and invalid streams of `want` messages and `have` replies.
+Each set of messages, as separated by an empty line, is to be considered as occurring on separate server connections.
 
 ```vt6
-(want core1 foo2)
-(have core1.0 foo2.3)
---> valid; client can now use core1.0 module and either foo2.0, foo2.1, foo2.2 or foo2.3 module
+(want core 1)
+(have core 1 0)
+(want foo 2)
+(have foo 2 3)
+--> client can now use core1.0 module and either foo2.0, foo2.1, foo2.2 or foo2.3 module
 
-(want core1 core2)
-(have core2.1)
---> valid; client can now use either core2.0 or core2.1 module, but not core1.x modules
+(want core 1 2)
+(have core 2 1)
+--> client can now use either core2.0 or core2.1 module, but not core1.x modules
 
-(want core1 foo.cap)
+(want core 1)
+(have core 1 0)
+(want foo.cap)
 (have)
---> "want" is invalid; cannot negotiate capability from foo1 before foo1 module has been agreed upon
+--> cannot negotiate capability from foo before usage of foo module has been agreed upon
 
-(want core1 foo1 foo.cap)
-(have core1.0 foo1.1)
---> valid; server has not agreed to capability
+(want core 1)
+(have core 1 0)
+(want foo 1 2)
+(have)
+(want foo.cap)
+(have)
+--> server did not agree to using foo module and thus cannot agree to using a capability from that module
 
-(want core1 foo1 foo.cap)
-(have core1.0 foo1.1 foo.cap)
---> valid; server has agreed to capability
+(want core 1)
+(have core 1 0)
+(want foo 1 2)
+(have foo 1 1)
+(want foo.cap)
+(have)
+--> server has not agreed to capability
 
-(want core1 foo1 foo.cap)
-(have foo.cap core1.0 foo.1)
---> "have" is invalid; argument order must match "want" message
-
-(want core1 foo1 bar1 foo.cap)
-(have core1.0 foo1.1 foo.cap)
---> valid; some modules not agreed to, but argument order is preserved
-
-(want core1 foo1)
-(have core1.0 bar1.0)
---> "have" is invalid; "have" argument "bar1.0" does not correspond to any "want" argument
+(want core 1)
+(have core 1 0)
+(want foo 1 2)
+(have foo 1 1)
+(want foo.cap)
+(have foo.cap)
+--> server has agreed to capability
 ```
 
 The server is under no obligation of agreeing to any module or capability.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -383,7 +383,7 @@ The first message that a client sends on each server connection MUST be a `want`
 
 - Directionality: server to client
 - Required capabilities: none
-- Number of arguments: zero, one or three
+- Number of arguments: zero, one or two
 
 Each argument MUST be a bareword.
 Quoted strings are not allowed in this message.
@@ -391,22 +391,26 @@ Quoted strings are not allowed in this message.
 *Rationale:* Same as in section 4.1.
 
 Upon receiving a valid `want` message, the server MUST reply with a `have` message to indicate if it agrees to using the requested module or capability.
-If the `want` message is valid, but the server does not agree to the requested module and capability, it MUST reply with a `have` message with zero arguments.
+If the `want` message is valid, but the server does not agree to the requested module or capability, it MUST reply with a `have` message with zero arguments.
 
-If the `want` message requests usage of a module and the server agrees to using that module, it MUST reply with a `have` message with three arguments: the module name, the major and minor version of the specification supported by the server.
+#### 4.2.1. Answering requests for modules
+
+If the `want` message requests usage of a module and the server agrees to using that module, it MUST reply with a `have` message with two arguments: the module name and the full version of the specification supported by the server.
 Receipt of this `have` message entitles the client to use all message types, properties and behavior defined in a specification of that module with the same major version number and the same, or a smaller, minor version number, except for functionality dependent on capabilities.
-The major and minor version MUST be formatted according to the `<major-version>` and `<minor-version>` grammar elements defined above.
-The major version in the `have` message MUST be one of the major versions that appeared in the original `want` message.
+The full version MUST be formatted according to the `<full-version>` grammar element defined above.
+The major version contained therein MUST be one of the major versions that appeared in the original `want` message.
 
 The server MUST NOT agree to using a module if it does not support any of the major versions of that module which were offered in the `want` message.
 The server MUST NOT agree to using multiple major versions of the same module, neither in a single `have` message or across multiple `have` messages on the same server connection.
 The server MAY agree to using different major versions of the same module on different server connections.
 
 When a `want` message concerns the same module as an earlier `want` message, the server MUST reply consistently.
-If it agreed to using a particular major version of a module in an earlier `have` message, and that major version is offered again in the current `have` message, it MUST agree to this major version and offer the same minor version as in the earlier `have` message.
+If it agreed to using a particular major version of a module in an earlier `have` message, and that major version is offered again in the current `have` message, it MUST agree to this major version and offer the same full version as in the earlier `have` message.
 If it did not agree to using a particular major version of a module in an earlier `have` message, and that major version is offered again in the current `have` message, it MUST NOT agree to this major version.
 
-If the `want` message requests usage of a capability and the server agrees to using that module, it MUST reply with a `have` message with a single argument: the capability name as accepted by `<scoped-name>`.
+#### 4.2.2. Answering requests for capabilities
+
+If the `want` message requests usage of a capability and the server agrees to using that capability, it MUST reply with a `have` message with a single argument: the capability name as accepted by `<scoped-name>`.
 Receipt of this `have` message entitles the client to use all message types, properties and behavior defined in a specification of that module with the same major version number and the same, or a smaller, minor version number, where such functionality depends on the negotiated capability.
 
 A server SHALL NOT agree to using a capability if it did not agree to using a module that defines this capability in any prior `have` message on the same server connection.
@@ -414,28 +418,30 @@ A server SHALL NOT agree to using a capability if it did not agree to using a mo
 When a `want` message concerns the same capability as an earlier `want` message, the server MUST reply consistently.
 If it agreed to using the capability in an earlier `have` message, it MUST agree to it again, and vice versa.
 
+#### 4.2.3. Examples
+
 The following snippet shows examples of valid and invalid streams of `want` messages and `have` replies.
 Each set of messages, as separated by an empty line, is to be considered as occurring on separate server connections.
 
 ```vt6
 (want core 1)
-(have core 1 0)
+(have core 1.0)
 (want foo 2)
-(have foo 2 3)
+(have foo 2.3)
 --> client can now use core1.0 module and either foo2.0, foo2.1, foo2.2 or foo2.3 module
 
 (want core 1 2)
-(have core 2 1)
+(have core 2.1)
 --> client can now use either core2.0 or core2.1 module, but not core1.x modules
 
 (want core 1)
-(have core 1 0)
+(have core 1.0)
 (want foo.cap)
 (have)
 --> cannot negotiate capability from foo before usage of foo module has been agreed upon
 
 (want core 1)
-(have core 1 0)
+(have core 1.0)
 (want foo 1 2)
 (have)
 (want foo.cap)
@@ -443,17 +449,17 @@ Each set of messages, as separated by an empty line, is to be considered as occu
 --> server did not agree to using foo module and thus cannot agree to using a capability from that module
 
 (want core 1)
-(have core 1 0)
+(have core 1.0)
 (want foo 1 2)
-(have foo 1 1)
+(have foo 1.1)
 (want foo.cap)
 (have)
 --> server has not agreed to capability
 
 (want core 1)
-(have core 1 0)
+(have core 1.0)
 (want foo 1 2)
-(have foo 1 1)
+(have foo 1.1)
 (want foo.cap)
 (have foo.cap)
 --> server has agreed to capability


### PR DESCRIPTION
This vastly simplifies implementations. The previous format looks nice on paper, but requires an absurd amount of bookkeeping on the server side.