### PR TITLE
WIP: vt6/term and vt6/mono modules

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -37,6 +37,12 @@ Analogously, when a property is said to **accept unsigned integer values**, this
 In both these cases, the **numerical value** of each such byte string is the decimal value of the sequence of digits in the byte string's value, possibly negated by a sign.
 The module specification defining the property may impose additional restrictions on the numerical value of the property.
 
+```abnf
+boolean = "t" / "f"
+```
+
+When a property is said to **accept boolean values**, this means that the set of acceptable values for this property consists of the two single-character strings `t` (true) and `f` (false).
+
 Module specifications which use some or all of the property types defined in this section SHALL reference this section.
 The recommended way to do so is by including the following sentence near the start of the specification:
 

--- a/spec/mono/1.0.md
+++ b/spec/mono/1.0.md
@@ -1,0 +1,63 @@
+<!-- draft -->
+# `vt6/mono1.0` - Monospace layouting on terminals
+
+The canonical URL for this document is <https://vt6.io/std/mono/1.0/>.
+
+**This is a non-normative draft.**
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+This document uses the predefined property types from [section 2.4 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-2-4).
+
+## 1. Scope
+
+This module extends the notion of terminals introduced in [`vt6/term`](https://vt6.io/std/term/) with additional definitions and assurances for text layouting using monospace fonts.
+Unless the `mono.enabled` property is set to true, clients MUST NOT assume that texts are rendered with monospace fonts.
+Clients that use strings of equal length and box-drawing characters to produce a layout may find that the actual rendering does not match their expectation.
+
+*Rationale:* The idea of character-grid layouts is fundamentally incompatible with wide Unicode support.
+Letters from non-Latin scripts rarely fit into grid cells whose size is optimized for Latin letters.
+Furthermore, the existence of combining characters and grapheme clusters means that applications cannot depend on the equivalence of "one character = one grid cell" when calculating the width that a certain string occupies on the character grid.
+That's why monospace layouting is not enabled by default.
+In fact, VT6-compliant terminals may not offer monospace layouting at all.
+
+### 1.1. Dependencies to other modules
+
+VT6 servers MUST NOT agree to using this module unless they have already agreed to using any version of `vt6/term` on the same server connection.
+
+### 1.2. Monospace layouting
+
+We take the term **terminal** to refer to a terminal as defined in [`vt6/term1.0`](https://vt6.io/std/term/1.0/).
+When the value of the `mono.enabled` property is changed, the server SHALL append a paragraph separator (U+2029) to the terminal document, and move the terminal's cursor to point at the end of the terminal document, after that paragraph separator.
+After this operation, the terminal's cursor SHALL NOT move past this paragraph separator, even when the specification of another module would allow it.
+
+*Rationale:* This ensures that that the cursor coordinates (see below) are well-defined.
+
+All text that is added to the terminal document while `mono.enabled` is true SHALL be displayed to the user using a monospace font, that is, a font where at least all printable ASCII characters have the same width.
+
+## 2. Message types for `vt6/mono1.0`
+
+None.
+
+TODO consider adding message types for querying and setting the cursor coordinates (we do not want to have this as a property since it would generate a metric ton of `core.pub` messages); cursor coordinates can be defined as y = number of linebreaks since `mono.enabled` was set to true, x = number of chars since last linebreak
+
+## 3. Properties for `vt6/mono1.0`
+
+### 3.1. The `mono.enabled` property
+
+- Acceptable values: booleans
+- Can be set by client: yes
+
+The value of this property indicates whether the terminal is in monospace layouting mode, as described in section 1.2.
+
+When this property is set by a client using a `core.set` message, and its server connection is then closed, the property SHALL be reset to the previous value, unless the property's value has also been set on some other server connection after that `core.set` message.
+
+*Rationale:* When a client sets `mono.enabled`, prints some text and exits, the shell will then observe the previous value of `mono.enabled` when printing its prompt.
+
+TODO consider upstreaming this scoping logic into core
+
+TODO Maybe setting this property should only be allowed for clients whose stdout is connected to the terminal.
+
+### 3.2. The `mono.tabwidth` property
+
+TODO unsigned integer (zero is not allowed)

--- a/spec/mono/1.0.md
+++ b/spec/mono/1.0.md
@@ -7,12 +7,13 @@ The canonical URL for this document is <https://vt6.io/std/mono/1.0/>.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-This document uses the predefined property types from [section 2.4 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-2-4).
+Unless stated otherwise, this document implies all definitions of terms made by [`vt6/foundation`](https://vt6.io/std/foundation/) and [`vt6/term1.0`](https://vt6.io/std/term/1.0/).
+This document uses the predefined property types from [`vt6/core1.0`](https://vt6.io/std/core/1.0/).
 
 ## 1. Scope
 
 This module extends the notion of terminals introduced in [`vt6/term`](https://vt6.io/std/term/) with additional definitions and assurances for text layouting using monospace fonts.
-Unless the `mono.enabled` property is set to true, clients MUST NOT assume that texts are rendered with monospace fonts.
+Unless the `mono1.enabled` property is set to true, clients MUST NOT assume that texts are rendered with monospace fonts.
 Clients that use strings of equal length and box-drawing characters to produce a layout may find that the actual rendering does not match their expectation.
 
 *Rationale:* The idea of character-grid layouts is fundamentally incompatible with wide Unicode support.
@@ -23,41 +24,40 @@ In fact, VT6-compliant terminals may not offer monospace layouting at all.
 
 ### 1.1. Dependencies to other modules
 
-VT6 servers MUST NOT agree to using this module unless they have already agreed to using any version of `vt6/term` on the same server connection.
+Terminals MUST NOT announce support for this module unless they announce support for any version of `vt6/term`.
 
 ### 1.2. Monospace layouting
 
-We take the term **terminal** to refer to a terminal as defined in [`vt6/term1.0`](https://vt6.io/std/term/1.0/).
-When the value of the `mono.enabled` property is changed, the server SHALL append a paragraph separator (U+2029) to the terminal document, and move the terminal's cursor to point at the end of the terminal document, after that paragraph separator.
+We take the term **terminal document** to refer to a terminal as defined in [`vt6/term1.0`](https://vt6.io/std/term/1.0/).
+When the value of the `mono1.enabled` property is changed, the terminal SHALL append a paragraph separator (U+2029) to the terminal document, and move the terminal's cursor to point at the end of the terminal document, after that paragraph separator.
 After this operation, the terminal's cursor SHALL NOT move past this paragraph separator, even when the specification of another module would allow it.
 
 *Rationale:* This ensures that that the cursor coordinates (see below) are well-defined.
 
-All text that is added to the terminal document while `mono.enabled` is true SHALL be displayed to the user using a monospace font, that is, a font where at least all printable ASCII characters have the same width.
+All text that is added to the terminal document while `mono1.enabled` is true SHALL be displayed to the user using a monospace font, that is, a font where at least all printable ASCII characters have the same width.
 
 ## 2. Message types for `vt6/mono1.0`
 
 None.
 
-TODO consider adding message types for querying and setting the cursor coordinates (we do not want to have this as a property since it would generate a metric ton of `core.pub` messages); cursor coordinates can be defined as y = number of linebreaks since `mono.enabled` was set to true, x = number of chars since last linebreak
+TODO consider adding message types for querying and setting the cursor coordinates (we do not want to have this as a property since it would generate a metric ton of `core1.pub` messages); cursor coordinates can be defined as y = number of linebreaks since `mono1.enabled` was set to true, x = number of chars since last linebreak
 
 ## 3. Properties for `vt6/mono1.0`
 
-### 3.1. The `mono.enabled` property
+### 3.1. The `mono1.enabled` property
 
 - Acceptable values: booleans
 - Can be set by client: yes
 
+This property is lifetime-bound, as defined in [`vt6/term1.0`](https://vt6.io/std/term/1.0/).
+The initial value is false.
+
+*Rationale:* When a client sets `mono1.enabled`, prints some text and exits, the shell will then observe the previous value of `mono1.enabled` when printing its prompt.
+
 The value of this property indicates whether the terminal is in monospace layouting mode, as described in section 1.2.
-
-When this property is set by a client using a `core.set` message, and its server connection is then closed, the property SHALL be reset to the previous value, unless the property's value has also been set on some other server connection after that `core.set` message.
-
-*Rationale:* When a client sets `mono.enabled`, prints some text and exits, the shell will then observe the previous value of `mono.enabled` when printing its prompt.
-
-TODO consider upstreaming this scoping logic into core
 
 TODO Maybe setting this property should only be allowed for clients whose stdout is connected to the terminal.
 
-### 3.2. The `mono.tabwidth` property
+### 3.2. The `mono1.tabwidth` property
 
 TODO unsigned integer (zero is not allowed)

--- a/spec/term/1.0.md
+++ b/spec/term/1.0.md
@@ -7,68 +7,65 @@ The canonical URL for this document is <https://vt6.io/std/term/1.0/>.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-This document uses the predefined property types from [section 2.4 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-2-4).
+Unless stated otherwise, this document implies all definitions of terms made by [`vt6/foundation`](https://vt6.io/std/foundation/) and other referenced modules.
+This document uses the predefined property types from [`vt6/core1.0`](https://vt6.io/std/core/1.0/).
 
 ## 1. Scope
 
 This module defines how a terminal works, how clients' standard output is reflected on the terminal, and how user input is presented on clients' standard input.
-Besides [`vt6/core`](https://vt6.io/std/core/), this is the only module that we expect to be available in **every** VT6 server implementation across the entire feature spectrum, from graphical terminal emulators all the way down to continuous stationery printers.
-
-This document uses the definitions introduced in [section 1 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-1).
-
-TODO review wording of entire document when the PR with the core.to-stdio message lands
+Besides [`vt6/core`](https://vt6.io/std/core/), this is the only module that we expect to be available in **every** VT6 terminal implementation across the entire feature spectrum, from graphical terminal emulators all the way down to continuous stationery printers.
 
 ### 1.1. Terminals
 
 A **Unicode document** is a string of Unicode characters with a cursor.
 The cursor points either at the start of the string (before the first character), at its end (after the last character) or between two adjacent characters.
 
-When a VT6 server agrees to using this module, it MUST have a Unicode document (the **terminal document**) that its clients can interact with as described in section 1.2.
+When a terminal reports support for this module version, it MUST have a Unicode document (the **terminal document**) that its clients can interact with as described in section 1.2.
 All clients MUST act upon the same terminal document.
 
-If the server takes text input from a user or some other source, it MAY pass this input to the clients as described in section 1.3.
+If the terminal takes text input from a user or some other source, it MAY pass this input to the clients as described in section 1.3.
 
-*Rationale:* This is a "MAY" because some servers (e.g. continuous stationery printers) do not have an input method, and because not all text input into a terminal application is intended to be standard input (e.g. input into a terminal's settings window).
+*Rationale:* This is a "MAY" because some terminals (e.g. continuous stationery printers) do not have an input method, and because not all text input into a terminal application is intended to be standard input (e.g. input into a terminal's settings window).
 
-The terminal document and its cursor SHOULD NOT be manipulated by the server in any way except for those ways specifically permitted in this specification and in the specifications for other VT6 module versions which the server has agreed to using.
+The terminal document and its cursor SHOULD NOT be manipulated by the terminal in any way except for those ways specifically permitted in this specification and in the specifications for other VT6 module versions supported by the terminal.
 
-*Rationale:* Clients should be able to rely on the server interpreting their standard output faithfully.
+*Rationale:* Clients should be able to rely on the terminal interpreting their standard output faithfully.
 
 ### 1.2. Standard output
 
-When the server receives a byte string written by a client into its standard output, the server SHALL assume that this byte string is encoded in [UTF-8](https://tools.ietf.org/html/rfc3629), and decode it into a string of Unicode characters.
+When the terminal receives a byte string written by a client into its standard output, the terminal SHALL assume that this byte string is encoded in [UTF-8](https://tools.ietf.org/html/rfc3629), and decode it into a string of Unicode characters.
 Invalid byte sequences or invalid code points SHALL be handled gracefully, for instance, by replacing them with the replacement character (U+FFFD).
 
-When the `term.output-protected` property is true, the server MUST then discard all active characters from this string.
+When the `term1.output-protected` property is true, the terminal MUST then discard all active characters from this string.
 **Active characters**, for the purpose of this specification, are all characters that are in the general categories Cc ("Other, control"), Cf ("Other, format"), Cs ("Other, surrogate"), Co ("Other, private use") and Cn ("Other, not assigned"), except for U+0009 (Horizontal Tab), U+000A (New Line), U+000C (Form Feed) and U+000D (Carriage Return).
-When the active character to be discarded is U+001B (Escape), the server MUST also discard characters directly succeeding it as follows:
+When the active character to be discarded is U+001B (Escape), the terminal MUST also discard characters directly succeeding it as follows:
 
 - When the next character after U+001B is from the range U+0040-U+005F, that character is also discarded.
-- When the character discarded in the previous step was U+005B (the opening bracket `[`), then any succeeding characters that are in the range U+0020-U+003F are also discarded, up until a character from the range U+0040-U+007F is encountered, which is also discarded. If any unexpected characters are found while searching for characters to discard, the server MAY choose to not discard anything except for the initial U+001B character.
+- When the character discarded in the previous step was U+005B (the opening bracket `[`), then any succeeding characters that are in the range U+0020-U+003F are also discarded, up until a character from the range U+0040-U+007F is encountered, which is also discarded. If any unexpected characters are found while searching for characters to discard, the terminal MAY choose to not discard anything except for the initial U+001B character.
 
 *Rationale:* That's how ANSI escape sequences are structured.
 
-When the `term.output-protected` property is false, the server MAY alternatively:
+When the `term1.output-protected` property is false, the terminal MAY alternatively:
 
 - choose a printable representation for each active character and replace the character with that representation before continuing, or
 - interpret the control sequence started by that active character if the character is U+001B (Escape).
 
-When a control character is interpreted as starting a control sequence, the entire control sequence SHALL be removed from the string before processing as described in this section continues, and the remaining string or the server's internal state MAY be modified depending on the semantics of the control sequence.
+When a control character is interpreted as starting a control sequence, the entire control sequence SHALL be removed from the string before processing as described in this section continues, and the remaining string or the terminal's internal state MAY be modified depending on the semantics of the control sequence.
 
 *Rationale:* This rule allows terminals to be backwards-compatible with legacy control sequences, such as those defined in VT100 aka ECMA-48 aka ANSI X3.64 aka ISO/IEC 6429.
 
 Characters that are in the general category Co ("Other, private use") MAY be exempted from the treatment described above if the characters in question have a graphic representation in the font that the terminal uses to display its character array.
 
-Finally, the server MUST discard each U+000A (new line) character that immediately succeeds a U+000D (carriage return) character, and then convert each U+000D character into a U+000A character.
+Finally, the terminal MUST discard each U+000A (new line) character that immediately succeeds a U+000D (carriage return) character, and then convert each U+000D character into a U+000A character.
 
 *Rationale:* This rule ensures consistent line break handling across different platforms, i.e., CR+NL = CR = NL.
 
 The remaining string of Unicode characters SHALL then be inserted into the terminal document at the position pointed to by the cursor.
 The cursor SHALL be updated to point at the position directly after the inserted string.
 
-If the terminal document would grow too large to fit within the program's memory because of this operation, the server MAY choose to discard some of the text at the start of the document.
+If the terminal document would grow too large to fit within the program's memory because of this operation, the terminal MAY choose to discard some of the text at the start of the document.
 If it does so, it SHOULD discard entire lines or paragraphs, that is, the last codepoint discarded SHOULD be U+000A, U+000C, U+2028 or U+2029.
-If the cursor points to the start of or into the discarded portion of the terminal document, it SHALL be moved to its end before the discarding.
+If the cursor points to the start of or into the discarded portion of the terminal document, it SHALL be moved to the end of the discarded portion before that portion is discarded.
 
 *Rationale:* Chomping off only parts of a line causes unnecessary confusion on the side of the user.
 
@@ -78,24 +75,36 @@ TODO describe how keypresses are reflected on stdin (canonical/raw mode, noecho 
 
 ### 1.4. Display
 
-If the server displays the document to a user, or renders it to some graphics device or file, then the terminal document SHALL be laid out according to the rules for normalization, writing direction, line breaking and handling of bidirectional text as defined in the Unicode Standard, as published by the [Unicode consortium](https://www.unicode.org).
+If the terminal displays the document to a user, or renders it to some graphics device or file, then the terminal document SHALL be laid out according to the rules for normalization, writing direction, line breaking and handling of bidirectional text as defined in the Unicode Standard, as published by the [Unicode consortium](https://www.unicode.org).
 
 The surface onto which the terminal document is rendered is called the **terminal viewport**.
 
-## 2. Properties for `vt6/term1`
+## 2. Message types for `vt6/term1.0`
 
-Several of the properties defined below are **connection-lifetime-scoped**.
-When a property is defined to be connection-lifetime-scoped, its value MUST be determined as follows:
+### 2.1. The `term1.eof` message
 
-- If there is at least one open server connection where the property's value has been set with a `core.set` message, the value of the property is the value requested by the corresponding client in that `core.set` message which has been received most recently by the server.
+- Role: event
+- Number of arguments: zero
+
+The `term1.eof` event indicates the end of a stream of user input.
+Clients SHOULD treat a `term1.eof` event as if they had encountered end-of-file on standard input.
+
+*Rationale:* This event replaces the explicit zero-length read that Ctrl-D triggers on a POSIX-compliant terminal.
+
+## 3. Properties for `vt6/term1.0`
+
+Several of the properties defined below are **lifetime-bound**.
+When a property is defined to be lifetime-bound, its value MUST be determined as follows:
+
+- If the terminal has received `core.set` requests for that property whose client IDs' lifetime has not yet ended, the value of the property is the value requested by the latest such `core.set` message.
 - Otherwise, the value of the property is the **initial value** for that property, as defined by its specification.
 
 This especially means that:
 
-- The value of the property may implicitly change whenever a server connection which has set the property value is closed.
-- All client requests to set the property value (using a `core.set` message) MUST be honored by the server. The new value of the property MUST be identical to the value requested by the client.
+- The value of the property may implicitly change whenever the lifetime of a client ID ends which has set the property value.
+- All client requests to set the property value (using a `core.set` message) MUST be honored by the terminal. The new value of the property MUST be identical to the value requested by the client.
 
-### 2.1. The `term.width` property
+### 3.1. The `term1.width` property
 
 - Acceptable values: unsigned integers
 - Can be set by client: no
@@ -105,18 +114,18 @@ The value of this property is the maximum number of printable ASCII characters (
 It MAY be computed as follows:
 
 1. For any printable ASCII codepoint `c`, let `N(c)` be the maximum length of a string containing only the codepoint `c`, such that a rendering of this string fits in the width of the terminal viewport without line breaks or overflows.
-2. The value of the `term.width` property is `N(c')` where `c'` is that value of `c` that minimizes `N(c)`.
+2. The value of the `term1.width` property is `N(c')` where `c'` is that value of `c` that minimizes `N(c)`.
 
-*Rationale:* This is a "MAY" because servers may employ more sophisticated computations to account for ligatures, or simpler computations if they use monospace fonts.
+*Rationale:* This is a "MAY" because terminals may employ more sophisticated computations to account for ligatures, or simpler computations if they use monospace fonts.
 
 The value of this property SHALL NOT be zero.
-If the computation above would result in a value of zero, the server SHALL report a value of one instead.
+If the computation above would result in a value of zero, the terminal SHALL report a value of one instead.
 
 *Rationale:* To avoid divide-by-zero bugs in client code.
 
 TODO move to vt6/mono, simplify accordingly
 
-### 2.2. The `term.viewport-height` property
+### 3.2. The `term1.viewport-height` property
 
 - Acceptable values: unsigned integers
 - Can be set by client: no
@@ -128,50 +137,50 @@ A value of zero indicates that the viewport is infinitely tall.
 
 TODO move to vt6/mono, simplify accordingly
 
-### 2.3. The `term.input-immediate` property
+### 3.3. The `term1.input-immediate` property
 
 - Acceptable values: booleans
 - Can be set by clients: yes
 
-This property is connection-lifetime-scoped, as defined above.
+This property is lifetime-bound, as defined above.
 The initial value is false.
 
-A value of true indicates that the server MUST make all input available to clients immediately, regardless of how many or which characters have been received.
+A value of true indicates that the terminal MUST make all input available to clients immediately, regardless of how many or which characters have been received.
 
-A value of false indicates that the server MAY buffer input and only make it available to clients once a certain condition has been met (most commonly, when an entire line of input has been received).
+A value of false indicates that the terminal MAY buffer input and only make it available to clients once a certain condition has been met (most commonly, when an entire line of input has been received).
 
-### 2.4. The `term.input-echo` property
+### 3.4. The `term1.input-echo` property
 
 - Acceptable values: booleans
 - Can be set by clients: yes
 
-This property is connection-lifetime-scoped, as defined above.
+This property is lifetime-bound, as defined above.
 The initial value is true.
 
-When the value of this property is true, all input that is made available to a client is also added to the terminal document as if its UTF-8-encoded form had been received by the server from a client's standard output.
+When the value of this property is true, all input that is made available to a client is also added to the terminal document as if its UTF-8-encoded form had been received by the terminal from a client's standard output.
 
-### 2.5. The `term.output-protected` property
+### 3.5. The `term1.output-protected` property
 
 - Acceptable values: booleans
 - Can be set by clients: yes
 
-This property is connection-lifetime-scoped, as defined above.
+This property is lifetime-bound, as defined above.
 The initial value is false.
 
 The semantics of this property are defined in section 1.2.
 
-### 2.6. The `term.output-reflow` property
+### 3.6. The `term1.output-reflow` property
 
 - Acceptable values: booleans
 - Can be set by clients: no
 
-A value of true indicates that the server reflows the entire terminal document when the viewport width (i.e., the value of the `term.viewport-width` property) changes.
+A value of true indicates that the terminal reflows the entire terminal document when the terminal viewport's width changes.
 
-A value of false indicates that the server MAY, after a viewport width change, continue to display unchanged parts of the terminal document according to the old viewport width.
+A value of false indicates that, after a viewport width change, the terminal MAY continue to display unchanged parts of the terminal document according to the old viewport width.
 
-### 2.7. The `term.output-wordwrap` property
+### 3.7. The `term1.output-wordwrap` property
 
 - Acceptable values: booleans
 - Can be set by clients: no
 
-The value of this property indicates whether, when rendering the terminal document onto the terminal viewport, the server tries to prevent breaking lines inside words.
+The value of this property indicates whether, when rendering the terminal document onto the terminal viewport, the terminal tries to prevent breaking lines inside words.

--- a/spec/term/1.0.md
+++ b/spec/term/1.0.md
@@ -1,0 +1,177 @@
+<!-- draft -->
+# `vt6/term1.0` - Universal terminal capabilities and input/output handling
+
+The canonical URL for this document is <https://vt6.io/std/term/1.0/>.
+
+**This is a non-normative draft.**
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+This document uses the predefined property types from [section 2.4 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-2-4).
+
+## 1. Scope
+
+This module defines how a terminal works, how clients' standard output is reflected on the terminal, and how user input is presented on clients' standard input.
+Besides [`vt6/core`](https://vt6.io/std/core/), this is the only module that we expect to be available in **every** VT6 server implementation across the entire feature spectrum, from graphical terminal emulators all the way down to continuous stationery printers.
+
+This document uses the definitions introduced in [section 1 of `vt6/core1.0`](https://vt6.io/std/core/1.0/#section-1).
+
+TODO review wording of entire document when the PR with the core.to-stdio message lands
+
+### 1.1. Terminals
+
+A **Unicode document** is a string of Unicode characters with a cursor.
+The cursor points either at the start of the string (before the first character), at its end (after the last character) or between two adjacent characters.
+
+When a VT6 server agrees to using this module, it MUST have a Unicode document (the **terminal document**) that its clients can interact with as described in section 1.2.
+All clients MUST act upon the same terminal document.
+
+If the server takes text input from a user or some other source, it MAY pass this input to the clients as described in section 1.3.
+
+*Rationale:* This is a "MAY" because some servers (e.g. continuous stationery printers) do not have an input method, and because not all text input into a terminal application is intended to be standard input (e.g. input into a terminal's settings window).
+
+The terminal document and its cursor SHOULD NOT be manipulated by the server in any way except for those ways specifically permitted in this specification and in the specifications for other VT6 module versions which the server has agreed to using.
+
+*Rationale:* Clients should be able to rely on the server interpreting their standard output faithfully.
+
+### 1.2. Standard output
+
+When the server receives a byte string written by a client into its standard output, the server SHALL assume that this byte string is encoded in [UTF-8](https://tools.ietf.org/html/rfc3629), and decode it into a string of Unicode characters.
+Invalid byte sequences or invalid code points SHALL be handled gracefully, for instance, by replacing them with the replacement character (U+FFFD).
+
+When the `term.output-protected` property is true, the server MUST then discard all active characters from this string.
+**Active characters**, for the purpose of this specification, are all characters that are in the general categories Cc ("Other, control"), Cf ("Other, format"), Cs ("Other, surrogate"), Co ("Other, private use") and Cn ("Other, not assigned"), except for U+0009 (Horizontal Tab), U+000A (New Line), U+000C (Form Feed) and U+000D (Carriage Return).
+When the active character to be discarded is U+001B (Escape), the server MUST also discard characters directly succeeding it as follows:
+
+- When the next character after U+001B is from the range U+0040-U+005F, that character is also discarded.
+- When the character discarded in the previous step was U+005B (the opening bracket `[`), then any succeeding characters that are in the range U+0020-U+003F are also discarded, up until a character from the range U+0040-U+007F is encountered, which is also discarded. If any unexpected characters are found while searching for characters to discard, the server MAY choose to not discard anything except for the initial U+001B character.
+
+*Rationale:* That's how ANSI escape sequences are structured.
+
+When the `term.output-protected` property is false, the server MAY alternatively:
+
+- choose a printable representation for each active character and replace the character with that representation before continuing, or
+- interpret the control sequence started by that active character if the character is U+001B (Escape).
+
+When a control character is interpreted as starting a control sequence, the entire control sequence SHALL be removed from the string before processing as described in this section continues, and the remaining string or the server's internal state MAY be modified depending on the semantics of the control sequence.
+
+*Rationale:* This rule allows terminals to be backwards-compatible with legacy control sequences, such as those defined in VT100 aka ECMA-48 aka ANSI X3.64 aka ISO/IEC 6429.
+
+Characters that are in the general category Co ("Other, private use") MAY be exempted from the treatment described above if the characters in question have a graphic representation in the font that the terminal uses to display its character array.
+
+Finally, the server MUST discard each U+000A (new line) character that immediately succeeds a U+000D (carriage return) character, and then convert each U+000D character into a U+000A character.
+
+*Rationale:* This rule ensures consistent line break handling across different platforms, i.e., CR+NL = CR = NL.
+
+The remaining string of Unicode characters SHALL then be inserted into the terminal document at the position pointed to by the cursor.
+The cursor SHALL be updated to point at the position directly after the inserted string.
+
+If the terminal document would grow too large to fit within the program's memory because of this operation, the server MAY choose to discard some of the text at the start of the document.
+If it does so, it SHOULD discard entire lines or paragraphs, that is, the last codepoint discarded SHOULD be U+000A, U+000C, U+2028 or U+2029.
+If the cursor points to the start of or into the discarded portion of the terminal document, it SHALL be moved to its end before the discarding.
+
+*Rationale:* Chomping off only parts of a line causes unnecessary confusion on the side of the user.
+
+### 1.3. Standard input
+
+TODO describe how keypresses are reflected on stdin (canonical/raw mode, noecho property, allow ANSI escape sequences for control keys, etc.), how Ctrl-D is handled
+
+### 1.4. Display
+
+If the server displays the document to a user, or renders it to some graphics device or file, then the terminal document SHALL be laid out according to the rules for normalization, writing direction, line breaking and handling of bidirectional text as defined in the Unicode Standard, as published by the [Unicode consortium](https://www.unicode.org).
+
+The surface onto which the terminal document is rendered is called the **terminal viewport**.
+
+## 2. Properties for `vt6/term1`
+
+Several of the properties defined below are **connection-lifetime-scoped**.
+When a property is defined to be connection-lifetime-scoped, its value MUST be determined as follows:
+
+- If there is at least one open server connection where the property's value has been set with a `core.set` message, the value of the property is the value requested by the corresponding client in that `core.set` message which has been received most recently by the server.
+- Otherwise, the value of the property is the **initial value** for that property, as defined by its specification.
+
+This especially means that:
+
+- The value of the property may implicitly change whenever a server connection which has set the property value is closed.
+- All client requests to set the property value (using a `core.set` message) MUST be honored by the server. The new value of the property MUST be identical to the value requested by the client.
+
+### 2.1. The `term.width` property
+
+- Acceptable values: unsigned integers
+- Can be set by client: no
+
+The value of this property is the maximum number of printable ASCII characters (Unicode codepoints U+0020-U+007F) that can be displayed on the terminal viewport without having to break the line or overflow the viewport.
+
+It MAY be computed as follows:
+
+1. For any printable ASCII codepoint `c`, let `N(c)` be the maximum length of a string containing only the codepoint `c`, such that a rendering of this string fits in the width of the terminal viewport without line breaks or overflows.
+2. The value of the `term.width` property is `N(c')` where `c'` is that value of `c` that minimizes `N(c)`.
+
+*Rationale:* This is a "MAY" because servers may employ more sophisticated computations to account for ligatures, or simpler computations if they use monospace fonts.
+
+The value of this property SHALL NOT be zero.
+If the computation above would result in a value of zero, the server SHALL report a value of one instead.
+
+*Rationale:* To avoid divide-by-zero bugs in client code.
+
+TODO move to vt6/mono, simplify accordingly
+
+### 2.2. The `term.viewport-height` property
+
+- Acceptable values: unsigned integers
+- Can be set by client: no
+
+The value of this property is the maximum number of lines that can be visible at once on the terminal viewport.
+A value of zero indicates that the viewport is infinitely tall.
+
+*Rationale:* Continuous stationery printers are a practical example of vertically unbounded viewports.
+
+TODO move to vt6/mono, simplify accordingly
+
+### 2.3. The `term.input-immediate` property
+
+- Acceptable values: booleans
+- Can be set by clients: yes
+
+This property is connection-lifetime-scoped, as defined above.
+The initial value is false.
+
+A value of true indicates that the server MUST make all input available to clients immediately, regardless of how many or which characters have been received.
+
+A value of false indicates that the server MAY buffer input and only make it available to clients once a certain condition has been met (most commonly, when an entire line of input has been received).
+
+### 2.4. The `term.input-echo` property
+
+- Acceptable values: booleans
+- Can be set by clients: yes
+
+This property is connection-lifetime-scoped, as defined above.
+The initial value is true.
+
+When the value of this property is true, all input that is made available to a client is also added to the terminal document as if its UTF-8-encoded form had been received by the server from a client's standard output.
+
+### 2.5. The `term.output-protected` property
+
+- Acceptable values: booleans
+- Can be set by clients: yes
+
+This property is connection-lifetime-scoped, as defined above.
+The initial value is false.
+
+The semantics of this property are defined in section 1.2.
+
+### 2.6. The `term.output-reflow` property
+
+- Acceptable values: booleans
+- Can be set by clients: no
+
+A value of true indicates that the server reflows the entire terminal document when the viewport width (i.e., the value of the `term.viewport-width` property) changes.
+
+A value of false indicates that the server MAY, after a viewport width change, continue to display unchanged parts of the terminal document according to the old viewport width.
+
+### 2.7. The `term.output-wordwrap` property
+
+- Acceptable values: booleans
+- Can be set by clients: no
+
+The value of this property indicates whether, when rendering the terminal document onto the terminal viewport, the server tries to prevent breaking lines inside words.


### PR DESCRIPTION
This is based on an earlier draft (#14) where monospace layouting was a capability within vt6/term. I chose to make an entirely new branch because so much has changed in vt6/core1.0 recently that stuff is way cleaner this way.

@laerling FYI - If you want to read this, start with `term1.0` and then continue with `mono1.0`. The latter depends on the former.