### PR TITLE
Setting a property does NOT imply subscribing to the property

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -458,21 +458,6 @@ The message is *not* invalid if the second argument is a value that is not permi
 
 *Rationale:* For non-trivial properties, the client might not have enough information to decide whether a given value is valid.
 
-That is, a `core.set` message implies a `core.sub` message on the same server connection for the same property.
-This does not mean, however, that a separate `core.pub` message must be sent to answer the implied `core.sub` message.
-For example:
-
-```vt6
-# this message...
-(core.set foo.bar desired-value)
-# ...implies this message...
-(core.sub foo.bar)
-# ...and may result in a reply like this
-(core.pub foo.bar actual-value)
-```
-
-*Rationale:* For properties that only need to be set once, this reduces the number of messages required from four (sub-pub-set-pub) to two (set-pub).
-
 A client's request to change the value of a property does not imply any obligation of the server to comply with this request.
 The server may refuse to change the property's value at all (especially if the property is read-only), it may comply with the request, or set the property to an entirely different value, as long as the value is valid according to the property's specification.
 This is why a `core.pub` message is sent as a reply for a `core.set` message.

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -458,7 +458,6 @@ The message is *not* invalid if the second argument is a value that is not permi
 
 *Rationale:* For non-trivial properties, the client might not have enough information to decide whether a given value is valid.
 
-Setting a property implies subscribing to the property.
 That is, a `core.set` message implies a `core.sub` message on the same server connection for the same property.
 This does not mean, however, that a separate `core.pub` message must be sent to answer the implied `core.sub` message.
 For example:


### PR DESCRIPTION
Why would it.

Trigger for this was the desire not to force clients to handle asynchronous messages from the server if they don't subscribe to them.
This PR is mainly for discussing possible ramifications of not implying a subscription after invoking `core.set`.