### PR TITLE
core1.0: refactor and refine specification of stdio and multiplexed mode

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -29,23 +29,27 @@ If no VT6 server is present, the client process SHALL not be considered a VT6 cl
 ### 1.2. Server connections
 
 A **bidirectional byte stream** is an object from which byte strings can be read and into which byte strings can be written.
-A VT6 client SHALL have access to a bidirectional byte stream, which is called this client's **standard input/output**.
+A bidirectional byte stream is either in **stdio mode**, in **message mode** or in **multiplexed mode**.
+The semantics of message mode and multiplexed mode are defined in section 2.2.
+The semantics of stdio mode are defined in [`vt6/term`](https://vt6.io/std/term/).
+
+A VT6 client SHALL have access to a bidirectional byte stream, which is called this client's **standard input/output** and MUST start out in stdio mode.
 
 A platform MAY define a method by which clients can gain access to further bidirectional byte streams.
-byte streams obtained through this method are called **server connections**.
+Bidirectional byte streams obtained through this method MUST start out in message mode.
+
+Bidirectional byte streams that are in message mode are called **server connections**.
 When a client writes a byte string into a server connection, it MUST NOT be received by any process but this client's server.
 When a client reads a byte string from a server connection, it SHALL have been sent by this client's server.
 The server SHALL be able to distinguish between server connections opened by different clients, as well as different server connections opened by the same client.
-This does not necessarily mean that the server can identify which server connection belongs to which client process.
+This does not necessarily mean that the server can identify which server connection belongs to which client process, or which server connections correspond to the same client process.
 
 *Rationale:* The server connection is separate from the standard input and output for scenarios where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
 In POSIX, the server connection replaces the [special capabilities of terminal devices](https://linux.die.net/man/3/termios).
 
-If a VT6 client has a method to obtain server connections, it is said to be operating in **normal mode**.
-Otherwise, it is said to be operating in **multiplexed mode**.
+When something is defined as happening when a server connection is closed, that thing SHALL happen only when the bidirectional byte stream that is that server connection is closed, not when it switches out of message mode.
 
-*Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional byte stream to their server and have no way of establishing a separate bidirectional byte stream to use as a server connection.
-The most prominent example of this is a client connected via a remote login protocol such as [SSH](https://tools.ietf.org/html/rfc4251).
+*Rationale:* This is an explicit clarification because the phrase "when a server connection is closed" could be misconstrued as also applying to when a server connection ceases to be a server connection (by switching out of message mode).
 
 ### 1.3. Message types and properties
 
@@ -254,21 +258,52 @@ A message stream is **fenced** when it is preceded by one ESC character and succ
 
 ### 2.2. Server-client communication
 
-When a VT6 client is running in normal mode, it sends messages to its server by writing a message stream into a server connection, and receives messages from the server by reading a message stream from the same server connection.
-Furthermore, it can read input data from standard input and write output data to standard output.
-This specification does not restrict the form of these input and output data.
+#### 2.2.1. Message mode
 
-When a VT6 client is running in multiplexed mode, it sends messages to its server by writing a *fenced* message stream onto the standard output.
-Any ESC character that is part of the output data or of a message inside the fenced message stream must be escaped by doubling it.
+When a VT6 client has a method of obtaining server connections (see section 1.1), it can send messages to its server by writing a message stream into a server connection, and receive replies from the server by reading a message stream from the same server connection.
 
-Conversely, a VT6 client running in multiplexed mode receives messages from its server by reading a *fenced* message stream from the standard input, whenever a single ESC character is encountered.
-Any two consecutive ESC characters SHALL be interpreted as a single ESC character in the input data or in the current message.
+#### 2.2.2. Entering multiplexed mode
 
-A VT6 client running in multiplexed mode MUST write the magic string `<ESC>[6V` (decimal byte sequence 27, 91, 54, 126) into the standard output before writing anything else.
-The magic string is not considered to be part of the output data nor does it start a fenced message stream, so the escaping rule for ESC characters stated above does not apply.
+*Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional byte stream to their server and have no direct way of establishing separate server connections.
+The most prominent example of this is a client connected via a remote login protocol such as [SSH](https://tools.ietf.org/html/rfc4251).
+Most clients will not need to implement multiplexed mode.
+The remote login protocol (e.g. the SSH server) SHOULD launch a muxer to provide the remote clients with a proper VT6 server.
 
-If the client fails to do so, all data written by the client into its standard output MUST be considered output data and the escaping rule for ESC characters does not apply.
-Furthermore, fenced message streams MUST NOT be written into the client's standard input, and the escaping rule for ESC characters does not apply to the input data written into it, either.
+A client can attempt to upgrade its standard input/output from stdio mode into multiplexed mode with the following procedure:
+
+*Rationale:* The upgrade is available to all clients, even those who have a method of obtaining server connections.
+This simplifies the server implementation since the server does not have to distinguish which clients have such a method and which don't.
+
+1. The client writes the magic string `<ESC>[6V` (decimal byte sequence 27, 91, 54, 126) into standard output.
+2. Once the client reads the same magic string from standard input, the standard input/output has switched to multiplexed mode.
+3. If, while waiting for this magic string, the client instead observes the magic string `<ESC>[0V` (decimal byte sequence 27, 91, 48, 126) on standard input, the upgrade to multiplexed mode has failed and the standard input/output remains in stdio mode.
+   The client SHALL assume that a VT6 server is not present (as defined in section 1.1), and it SHALL NOT attempt to upgrade to multiplexed mode using this procedure ever again.
+
+*Rationale:* The magic strings used in this procedure are valid (and, to our knowledge, unallocated) ANSI escape sequences, so it should just be ignored by legacy terminals that are not VT6 servers.
+The server must reply with the same magic string for two reasons: as an additional check that the server is really VT6-capable and not just a legacy terminal, and to provide an explicit sequencing point after which the client has to apply the multiplexing rules to stdin.
+The server may have written to the client's stdin after the client has sent the magic string, but before the server received it; the explicit magic string allows the client to distinguish that.
+Point 3 allows legacy terminals to unblock clients waiting for a protocol upgrade that won't come.
+
+A server that receives the magic string `<ESC>[6V` over a bidirectional byte stream in stdio mode SHALL immediately answer with either `<ESC>[6V` or `<ESC>[0V` on the same bidirectional byte stream, and afterwards consider the stream to be in multiplexed mode if it sent `<ESC>[6V`.
+
+When standard input/output is transmitted over the network, the transport protocol SHOULD indicate early whether the terminal is VT6-capable, and the transport-level program on the side of the client SHOULD send `<ESC>[0V` into the client's standard input if it knows that the terminal is not VT6-capable.
+
+*Rationale:* This avoids an additional network round-trip for an upgrade procedure that is known to fail.
+
+#### 2.2.3. Multiplexed mode
+
+A bidirectional byte stream in multiplexed mode (henceforth called the "multiplexing stream") multiplexes two separate bidirectional byte streams, one operating in stdio mode and one operating in message mode, according to the following rules:
+
+1. The client can send messages to the server by writing a fenced message stream into the multiplexing stream.
+   The message stream, without the fencing ESC characters, is to be interpreted as being written into the underlying message-mode bidirectional byte stream.
+2. The client can receive messages from the server by reading a fenced message stream from the multiplexing stream.
+   The message stream, without the fencing ESC characters, is to be interpreted as having been read from the underlying message-mode bidirectional byte stream.
+3. When the client wants to write a byte string into the underlying stdio-mode bidirectional byte stream, it writes that byte string into the multiplexing stream while no fenced message stream is being written to it.
+   If the byte string contains any ESC characters, they MUST be escaped by doubling them.
+4. Whenever the client reads a byte string from the multiplexing stream that is not part of a fenced message stream, it SHALL interpret that byte string as having been read from the underlying stdio-mode bidirectional byte stream.
+   Any two consecutive ESC bytes SHALL be interpreted as a single ESC character in the byte string that was read from the underlying stdio-mode bidirectional byte stream.
+5. The client SHALL NOT attempt to perform the upgrade procedure described in section 2.2.2 on the underlying stdio-mode bidirectional byte stream.
+   If the server observes such an attempt, that is, when it reads `<ESC><ESC>[6V` from the multiplexing stream outside a fenced message stream, it MUST answer negatively, that is, by writing `<ESC><ESC>[0V` into the multiplexing stream outside a fenced message stream.
 
 ### 2.3. Invalid messages, and handling thereof
 
@@ -461,6 +496,19 @@ The client SHOULD observe the `core.pub` reply to learn whether the requested ch
 
 *Rationale:* For example, consider the case of the client trying to set `core.client-msg-bytes-max` to a larger value.
 The server might reject this, and report the previous value in the `core.pub` response; or it might choose a value inbetween the previous and the requested value because it absolutely cannot process messages larger than that.
+
+### 5.4 The `core.to-stdio` message
+
+*Rationale:* This message allows a shell or other client-spawning client to obtain separate standard input/output channels for new clients.
+
+- Directionality: both
+- Number of arguments: zero
+
+Upon receiving a valid `core.to-stdio` message, a server MUST reply with an identical message on the same server connection.
+After this exchange, that bidirectional byte stream switches from message mode into stdio mode.
+All bytes that flow through it (in either direction) after the trailing `}` of the `core.to-stdio` message SHALL be interpreted according to the rules for stdio mode.
+
+Messages of this type are invalid when transmitted in a fenced message stream over a bidirectional byte stream in multiplexed mode.
 
 ## 6. Properties for `vt6/core1.0`
 

--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -267,7 +267,7 @@ When a VT6 client has a method of obtaining server connections (see section 1.1)
 *Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional byte stream to their server and have no direct way of establishing separate server connections.
 The most prominent example of this is a client connected via a remote login protocol such as [SSH](https://tools.ietf.org/html/rfc4251).
 Most clients will not need to implement multiplexed mode.
-The remote login protocol (e.g. the SSH server) SHOULD launch a muxer to provide the remote clients with a proper VT6 server.
+The remote login provider (e.g. the SSH server) should be connected to a muxer to provide the remote clients with a proper VT6 server.
 
 A client can attempt to upgrade its standard input/output from stdio mode into multiplexed mode with the following procedure:
 

--- a/spec/posix/1.0.md
+++ b/spec/posix/1.0.md
@@ -20,11 +20,11 @@ POSIX allows processes to be started while a VT6 server is not present.
 Therefore, VT6 clients MUST use the following method to determine whether a VT6 server is present.
 
 1. If the `VT6` environment variable is present, its content is the absolute path to a socket file.
-   In this case, the VT6 client SHALL assume that a VT6 server is present, and operate in normal mode.
+   In this case, the VT6 client SHALL assume that a VT6 server is present.
    To obtain a server connection, the VT6 client SHALL connect to this socket file with socket type `SOCK_SEQPACKET`, and upon success, use the open socket as a server connection.
    When the connection to the socket fails, the VT6 client MAY either bail out, or continue to operate as if no VT6 server is present.
 
-2. If the `TERM` environment variable is present and contains the string `vt6`, the VT6 client SHALL assume that a VT6 server is present, and operate in multiplexed mode.
+2. If the `TERM` environment variable is present and contains the string `vt6`, the VT6 client SHALL assume that a VT6 server is present, but that there is no method to obtain server connections.
 
 3. If the `VT6` environment variable is absent and the `TERM` environment variable does not contain the string `vt6`, the VT6 client MUST consider the VT6 server to be absent.
 


### PR DESCRIPTION
As discussed in #32 (the PR for the vt6/term and vt6/mono modules), this moves the spawning of stdios into core, with the new core.to-stdio message.

While writing the spec for the core.to-stdio message, it occurred to me that the dichotomy between "normal-mode clients" and "multiplexed-mode clients" is misplaced. A normal-mode client (such as the SSH client) must be able to spawn a bidirectional byte stream that is then used as the stdio of a multiplexed-mode program. This commit moves the modes to the level of individual bidirectional byte streams to fix this.

A bidirectional byte stream usually starts out in message mode, can be moved into stdio mode with the core.to-stdio message, and upgraded to multiplexed mode when the client cannot spawn additional server connections.

The upgrade procedure for entering multiplexed mode changes as follows:

- The initial `<ESC>[6V` need not be the first thing that the client writes. Consider the case of SSH: The SSH server may print a login message (e.g. /etc/motd) or other log messages before transferring control to the shell (or the muxer that provides the VT6 server on the remote side), so we should allow for `<ESC>[6V` to happen after text has already been printed to stdout.

- Since this now means that stdio may be used for output before the upgrade to multiplexed mode, we must assume that it is also used for input. To avoid ambiguity or race conditions, we need to mark the
  point where the server has seen the `<ESC>[6V` and stdin switches to multiplexed mode. The server therefore now has to reply with `<ESC>[6V` if it agrees to the upgrade.

- A problem with this approach is that the client may now be blocked if the terminal is not VT6-capable and just ignores the `<ESC>[6V`. To somewhat ameliorate this issue, there is a new magic string, `<ESC>[0V`, that legacy terminals can use to explicitly reject the upgrade to multiplexed mode. A "SHOULD" is added with advise how SSH (or other transport-level programs) can improve the user experience when remote VT6 clients connect to legacy terminals.

Since the term "bidirectional byte stream" now becomes much more prominent, the term "server connection" is redefined as "bidirectional byte stream in message mode".