### PR TITLE
initial spec for the posix.to-{stdin,stdout} message types

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -38,8 +38,8 @@ A VT6 client SHALL have access to a bidirectional byte stream, which is called t
 A platform MAY define a method by which clients can gain access to further bidirectional byte streams.
 Bidirectional byte streams obtained through this method MUST start out in message mode.
 
-Bidirectional byte streams that are in message mode are called **server connections**.
-When a client writes a byte string into a server connection, it MUST NOT be received by any process but this client's server.
+Bidirectional byte streams that are in message mode or multiplexed mode are called **server connections**.
+When a client writes a byte string into a server connection, the same byte string MUST be received unaltered by this client's server.
 When a client reads a byte string from a server connection, it SHALL have been sent by this client's server.
 The server SHALL be able to distinguish between server connections opened by different clients, as well as different server connections opened by the same client.
 This does not necessarily mean that the server can identify which server connection belongs to which client process, or which server connections correspond to the same client process.
@@ -47,9 +47,9 @@ This does not necessarily mean that the server can identify which server connect
 *Rationale:* The server connection is separate from the standard input and output for scenarios where the VT6 client must be certain that the messages it sends are received by the VT6 server and not by another party (such as the next client in a shell pipe), and vice versa for server-to-client messages.
 In POSIX, the server connection replaces the [special capabilities of terminal devices](https://linux.die.net/man/3/termios).
 
-When something is defined as happening when a server connection is closed, that thing SHALL happen only when the bidirectional byte stream that is that server connection is closed, not when it switches out of message mode.
+When something is defined as happening when a server connection is closed, that thing SHALL happen only when the bidirectional byte stream that is that server connection is closed, not when it switches out of message mode or multiplexed mode.
 
-*Rationale:* This is an explicit clarification because the phrase "when a server connection is closed" could be misconstrued as also applying to when a server connection ceases to be a server connection (by switching out of message mode).
+*Rationale:* This is an explicit clarification because the phrase "when a server connection is closed" could be misconstrued as also applying to when a server connection ceases to be a server connection (e.g. by switching from message mode into stdio mode).
 
 ### 1.3. Message types and properties
 
@@ -248,23 +248,15 @@ A **VT6 message stream** (or just **message stream**, if the term is not ambiguo
 
 *Rationale:* Allowing for whitespace between messages is especially useful when messages are emitted by a script in a language where a `print` operation appends a line separator by default.
 
-```abnf
-fenced-message-stream = escape-char message-stream escape-char
-
-escape-char = %x1B
-```
-
-A message stream is **fenced** when it is preceded by one ESC character and succeeded by another ESC character.
-
 ### 2.2. Server-client communication
 
 #### 2.2.1. Message mode
 
-When a VT6 client has a method of obtaining server connections (see section 1.1), it can send messages to its server by writing a message stream into a server connection, and receive replies from the server by reading a message stream from the same server connection.
+When a VT6 client has a method of obtaining bidirectional byte streams in message mode (see section 1.1), it can send messages to its server by writing a message stream into one of these streams, and receive replies from the server by reading a message stream from the same stream.
 
 #### 2.2.2. Entering multiplexed mode
 
-*Rationale:* The multiplexed mode is intended for clients which only have a single bidirectional byte stream to their server and have no direct way of establishing separate server connections.
+*Rationale:* Multiplexed mode is intended for clients which only have a single bidirectional byte stream to their server and have no direct way of establishing separate server connections.
 The most prominent example of this is a client connected via a remote login protocol such as [SSH](https://tools.ietf.org/html/rfc4251).
 Most clients will not need to implement multiplexed mode.
 The remote login provider (e.g. the SSH server) should be connected to a muxer to provide the remote clients with a proper VT6 server.
@@ -292,18 +284,12 @@ When standard input/output is transmitted over the network, the transport protoc
 
 #### 2.2.3. Multiplexed mode
 
-A bidirectional byte stream in multiplexed mode (henceforth called the "multiplexing stream") multiplexes two separate bidirectional byte streams, one operating in stdio mode and one operating in message mode, according to the following rules:
+When a VT6 client has access to a bidirectional byte stream in multiplexed mode, it can send messages to its server by writing fenced message streams into it, and receive replies from the server by reading fenced message streams from it.
+A message stream is **fenced** when it is preceded by one ESC byte (decimal value 27) and succeeded by another ESC byte, and all ESC bytes that occur in the message stream are escaped by doubling them.
 
-1. The client can send messages to the server by writing a fenced message stream into the multiplexing stream.
-   The message stream, without the fencing ESC characters, is to be interpreted as being written into the underlying message-mode bidirectional byte stream.
-2. The client can receive messages from the server by reading a fenced message stream from the multiplexing stream.
-   The message stream, without the fencing ESC characters, is to be interpreted as having been read from the underlying message-mode bidirectional byte stream.
-3. When the client wants to write a byte string into the underlying stdio-mode bidirectional byte stream, it writes that byte string into the multiplexing stream while no fenced message stream is being written to it.
-   If the byte string contains any ESC characters, they MUST be escaped by doubling them.
-4. Whenever the client reads a byte string from the multiplexing stream that is not part of a fenced message stream, it SHALL interpret that byte string as having been read from the underlying stdio-mode bidirectional byte stream.
-   Any two consecutive ESC bytes SHALL be interpreted as a single ESC character in the byte string that was read from the underlying stdio-mode bidirectional byte stream.
-5. The client SHALL NOT attempt to perform the upgrade procedure described in section 2.2.2 on the underlying stdio-mode bidirectional byte stream.
-   If the server observes such an attempt, that is, when it reads `<ESC><ESC>[6V` from the multiplexing stream outside a fenced message stream, it MUST answer negatively, that is, by writing `<ESC><ESC>[0V` into the multiplexing stream outside a fenced message stream.
+Any byte strings written into a bidirectional byte stream in multiplexed mode which are not part of a fenced message stream SHALL be interpreted by the recipient as if they had been written into that bidirectional byte stream in that same direction while it was in stdio mode.
+In other words, the client can write standard output into the bidirectional byte stream directly, inbetween fenced message streams, and the server can conversely send standard input to the client by writing into the bidirectional byte stream directly, inbetween fenced message streams.
+As an exception, all ESC bytes that are part of the byte strings thus transferred MUST be escaped by doubling them.
 
 ### 2.3. Invalid messages, and handling thereof
 
@@ -508,7 +494,7 @@ Upon receiving a valid `core.to-stdio` message, a server MUST reply with an iden
 After this exchange, that bidirectional byte stream switches from message mode into stdio mode.
 All bytes that flow through it (in either direction) after the trailing `}` of the `core.to-stdio` message SHALL be interpreted according to the rules for stdio mode.
 
-Messages of this type are invalid when transmitted in a fenced message stream over a bidirectional byte stream in multiplexed mode.
+Messages of this type are invalid when transmitted over a bidirectional byte stream in multiplexed mode.
 
 ## 6. Properties for `vt6/core1.0`
 

--- a/spec/posix/1.0.md
+++ b/spec/posix/1.0.md
@@ -12,7 +12,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 Operating systems that implement the [POSIX.1 specification](http://pubs.opengroup.org/onlinepubs/9699919799/) are admissible environments for VT6 clients and servers.
 This module defines how various platform-specific mechanisms throughout VT6 work on such operating systems.
 
-## 2. Definitions for the `vt6/core1.0` module
+## 2. Definitions
+
+### 2.1. Definitions for the `vt6/core1.0` module
 
 Standard input and output for each VT6 client are the file descriptors 0 and 1 of that process, respectively.
 
@@ -28,7 +30,7 @@ Therefore, VT6 clients MUST use the following method to determine whether a VT6 
 
 3. If the `VT6` environment variable is absent and the `TERM` environment variable does not contain the string `vt6`, the VT6 client MUST consider the VT6 server to be absent.
 
-## 3. Definitions for the `vt6/sig1.0` module
+### 2.2. Definitions for the `vt6/sig1.0` module
 
 VT6 signals are dispatched to clients by sending the corresponding POSIX signals to the client processes:
 
@@ -42,3 +44,22 @@ When there is a signal dispatcher, the signal dispatcher SHALL use at least one 
 If the signal dispatcher can distinguish between client processes running in the foreground or in the background, it SHOULD use multiple process groups to track which processes are running in the foreground and send the POSIX signals to the current foreground process group only.
 
 When a server or signal dispatcher uses the `SIGSTOP` signal to suspend processes, the `SIGCONT` signal SHALL be used to resume these processes once the user instructs the server or signal dispatcher to do so.
+
+## 3. Message types for `vt6/posix1.0`
+
+### 3.1. The `posix.to-stdin` and `posix.to-stdout` messages
+
+- Directionality: both
+- Number of arguments: zero
+
+Upon receiving a valid `posix.to-stdin` or `posix.to-stdout` message, a server MUST reply with an identical message on the same server connection.
+Messages of this type are invalid when transmitted in a fenced message stream over a bidirectional byte stream in multiplexed mode.
+
+These two message types SHALL otherwise be considered identical to `core.to-stdio`, except that the following restrictions apply to the bidirectional byte stream over which they are exchanged:
+
+* When a stream has been set into stdio mode by a pair of `posix.to-stdin` messages, the client SHALL NOT write any bytes into the stream, and the server SHALL disregard any bytes it reads from the stream.
+* When a stream has been set into stdio mode by a pair of `posix.to-stdout` messages, the server SHALL NOT write any bytes into the stream, and the client SHALL disregard any bytes it reads from the stream.
+
+*Rationale:* These messages can be used to set up separate standard input and output channels that can be closed separately.
+When a shell sets up a command's stdin and stdout using separate bidirectional byte streams, the server can approximate the traditional Ctrl-D behavior by closing the command's standard input (i.e., the bidirectional byte stream most recently set into stdio mode by a pair of `posix.to-stdin` messages), then reading the remaining output from the command's standard output.
+If the command was instead connected by a single bidirectional byte stream which was set up with `core.to-stdio` messages, closing the standard input in order to terminate the client would make it impossible for the server to read standard output that was printed during shutdown (which for some programs, e.g. `sort(1)`, is all output).

--- a/spec/posix/1.0.md
+++ b/spec/posix/1.0.md
@@ -53,12 +53,13 @@ When a server or signal dispatcher uses the `SIGSTOP` signal to suspend processe
 - Number of arguments: zero
 
 Upon receiving a valid `posix.to-stdin` or `posix.to-stdout` message, a server MUST reply with an identical message on the same server connection.
-Messages of this type are invalid when transmitted in a fenced message stream over a bidirectional byte stream in multiplexed mode.
+Messages of this type are invalid when transmitted over a bidirectional byte stream in multiplexed mode.
 
-These two message types SHALL otherwise be considered identical to `core.to-stdio`, except that the following restrictions apply to the bidirectional byte stream over which they are exchanged:
+These two message types SHALL otherwise be considered identical to `core.to-stdio`, except that they switch their bidirectional byte stream into **stdin mode** and **stdout mode**, respectively.
 
-* When a stream has been set into stdio mode by a pair of `posix.to-stdin` messages, the client SHALL NOT write any bytes into the stream, and the server SHALL disregard any bytes it reads from the stream.
-* When a stream has been set into stdio mode by a pair of `posix.to-stdout` messages, the server SHALL NOT write any bytes into the stream, and the client SHALL disregard any bytes it reads from the stream.
+A bidirectional byte stream in stdin mode behaves as though in stdio mode, except that the client SHALL NOT write any bytes into the stream, and the server SHALL disregard any bytes it reads from the stream.
+
+A bidirectional byte stream in stdout mode behaves as though in stdio mode, except that the server SHALL NOT write any bytes into the stream, and the client SHALL disregard any bytes it reads from the stream.
 
 *Rationale:* These messages can be used to set up separate standard input and output channels that can be closed separately.
 When a shell sets up a command's stdin and stdout using separate bidirectional byte streams, the server can approximate the traditional Ctrl-D behavior by closing the command's standard input (i.e., the bidirectional byte stream most recently set into stdio mode by a pair of `posix.to-stdin` messages), then reading the remaining output from the command's standard output.


### PR DESCRIPTION
This half-fixes #26. I won't call this a complete fix. The other half could be an explicit EOF signal that works similar to the signals in `vt6/sig`.