### PR TITLE
Fix: Some places on the website still reference the old spec

### DIFF
--- a/spec/core/1.0.md
+++ b/spec/core/1.0.md
@@ -34,7 +34,7 @@ sign = "+" / "-"
 When a property is said to **accept integer values**, this means that the set of acceptable values for this property is the set of all byte strings whose value matches the `<integer>` grammar element defined above.
 Analogously, when a property is said to **accept unsigned integer values**, this means that the set of acceptable values for this property is the set of all byte strings whose value matches the `<unsigned-integer>` grammar element defined above.
 
-In both these cases, the **numerical value** of each such byte string is the decimal value of the sequence of digits in the byte string's value.
+In both these cases, the **numerical value** of each such byte string is the decimal value of the sequence of digits in the byte string's value, possibly negated by a sign.
 The module specification defining the property may impose additional restrictions on the numerical value of the property.
 
 Module specifications which use some or all of the property types defined in this section SHALL reference this section.

--- a/website/pages/std.md
+++ b/website/pages/std.md
@@ -17,6 +17,8 @@ Every VT6 terminal (or proxy) needs to implement at least two modules:
 
 * [vt6/core](core/) It contains the most basic parts of the VT6 protocol that can be versioned, such as basic property types and some message types for handling properties and lifetimes. The only thing more basic is [`vt6/foundation`](https://vt6.io/std/foundation/) which contains the unversionable parts of the VT6 protocol.
 
+* [vt6/term](term/) provides a conceptual model for what a terminal is, how a client can influence it by writing to standard output and how the standard input of a client works.
+
 Furthermore, every terminal must implement a platform integration module. A platform integration modules defines the platform-specific behavior that all other modules reference. The following platform integration modules exist as of now:
 
 * [vt6/posix](posix/) is for terminals and clients running on a POSIX-compliant operating system, such as Linux or any BSD.

--- a/website/pages/std.md
+++ b/website/pages/std.md
@@ -3,9 +3,9 @@
 **This document is non-normative**.
 
 The VT6 protocol is structured into versioned **modules**.
-Servers and clients negotiate which VT6 modules, and versions thereof, they understand.
+Terminals and clients negotiate which VT6 modules, and versions thereof, they understand.
 
-Through the module structure, VT6 can adapt to clients and servers with vastly different feature sets.
+Through the module structure, VT6 can adapt to clients and terminals with vastly different feature sets.
 Through the use of versioning, new capabilities can be added and old functionality can be deprecated without having to break interoperability with old implementations.
 
 The navigation bar at the top of the screen shows all the modules that currently exist. `Foundation` is an exception, since it defines fundamental protocols and interface contracts, and is not a versioned module that can be negotiated.
@@ -13,19 +13,19 @@ For each module, there is an overview page, such as https://vt6.io/std/core/, th
 
 ## Foundation
 
-Every VT6 server (that is, every terminal, proxy, etc.) needs to implement at least two modules:
+Every VT6 terminal (or proxy) needs to implement at least two modules:
 
 * [vt6/core](core/) It contains the most basic parts of the VT6 protocol that can be versioned, such as basic property types and some message types for handling properties and lifetimes. The only thing more basic is [`vt6/foundation`](https://vt6.io/std/foundation/) which contains the unversionable parts of the VT6 protocol.
 
-Furthermore, every server must implement a platform integration module. A platform integration modules defines the platform-specific behavior that all other modules reference. The following platform integration modules exist as of now:
+Furthermore, every terminal must implement a platform integration module. A platform integration modules defines the platform-specific behavior that all other modules reference. The following platform integration modules exist as of now:
 
-* [vt6/posix](posix/) is for servers and clients running on a POSIX-compliant operating system, such as Linux or any BSD.
+* [vt6/posix](posix/) is for terminals and clients running on a POSIX-compliant operating system, such as Linux or any BSD.
 
-A server that implements only vt6/core, vt6/term and a platform integration module (but no legacy ANSI escape sequences) is roughly comparable in functionality to a line printer.
+A terminal that implements only vt6/core, vt6/term and a platform integration module (but no legacy ANSI escape sequences) is roughly comparable in functionality to a line printer.
 
 ## Common modules
 
-Clients can expect the modules in this section to be supported by most server implementations, except for those on very constrained hardware like embedded systems.
+Clients can expect the modules in this section to be supported by most terminal implementations, except for those on very constrained hardware like embedded systems.
 
 * [vt6/sig](sig/) provides a basic signal handling mechanism, allowing the user to interrupt, terminate, or suspend running programs.
 

--- a/website/pages/std.md
+++ b/website/pages/std.md
@@ -3,20 +3,19 @@
 **This document is non-normative**.
 
 The VT6 protocol is structured into versioned **modules**.
-Before exchanging messages, servers and clients negotiate which VT6 modules, and versions thereof, they understand.
+Servers and clients negotiate which VT6 modules, and versions thereof, they understand.
 
 Through the module structure, VT6 can adapt to clients and servers with vastly different feature sets.
 Through the use of versioning, new capabilities can be added and old functionality can be deprecated without having to break interoperability with old implementations.
 
-The navigation bar at the top of the screen shows all the modules that currently exist. For each module, there is a overview page, such as https://vt6.io/std/core/, that explains the module, its core features and how it fits together with other modules. Below this path, you can find the normative specifications for each module version, such as https://vt6.io/std/core/1.0/.
+The navigation bar at the top of the screen shows all the modules that currently exist. `Foundation` is an exception, since it defines fundamental protocols and interface contracts, and is not a versioned module that can be negotiated.
+For each module, there is an overview page, such as https://vt6.io/std/core/, that explains the module, its core features and how it fits together with other modules. Below this path, you can find the normative specifications for each module version, such as https://vt6.io/std/core/1.0/.
 
 ## Foundation
 
 Every VT6 server (that is, every terminal, proxy, etc.) needs to implement at least two modules:
 
-* [vt6/core](core/) describes how clients connect to and exchange messages with their server. It formally defines fundamental concepts like modules, message types and properties, and how their usage is negotiated between server and client, and it defines basic message types for interacting with properties.
-
-* [vt6/term](term/) provides a conceptual model for what a terminal is, how a client can influence it by writing to standard output and how the standard input of a client works.
+* [vt6/core](core/) It contains the most basic parts of the VT6 protocol that can be versioned, such as basic property types and some message types for handling properties and lifetimes. The only thing more basic is [`vt6/foundation`](https://vt6.io/std/foundation/) which contains the unversionable parts of the VT6 protocol.
 
 Furthermore, every server must implement a platform integration module. A platform integration modules defines the platform-specific behavior that all other modules reference. The following platform integration modules exist as of now:
 


### PR DESCRIPTION
Also:
- std.md: Servers and clients don't necessarily negotiate modules
  before using them, see section 4 in foundation.
- Update reference to core module. Much of what it used to contain is
  in foundation now. I used the introductory description from the core
  module specification itself.
- Remove reference to term module. It lives in #32